### PR TITLE
feat(electron-client): add saving test file to local storage location

### DIFF
--- a/apps/electron-client/src/channels/CreateRecordingChannel.ts
+++ b/apps/electron-client/src/channels/CreateRecordingChannel.ts
@@ -1,0 +1,82 @@
+import { IpcChannel, IpcRequest } from '@/types'
+import { ipcMain, IpcMainEvent } from 'electron'
+import { writeFile } from 'fs/promises'
+import path from 'path'
+
+export class CreateRecordingChannel implements IpcChannel {
+  name = 'recorder:start'
+  private responseChannel: string | null = null
+  async handle(event: IpcMainEvent, request: IpcRequest) {
+    const { responseChannel, data } = request
+    if (!responseChannel) {
+      throw new Error(`No response channel provided for recorder:start request`)
+    }
+
+    if (!isValidCreateRecordingRequestData(data)) {
+      throw new Error(`Invalid data provided for recorder:start request`)
+    }
+
+    if (!this.responseChannel) {
+      this.responseChannel = responseChannel
+      this.registerResponse(event, request)
+    }
+    event.sender.send(responseChannel, {
+      success: true,
+    })
+  }
+
+  private async registerResponse(event: IpcMainEvent, request: IpcRequest) {
+    ipcMain.on('recorder:stop', async () => {
+      if (!this.responseChannel) {
+        throw new Error(
+          `No response channel provided for recorder:stop request`,
+        )
+      }
+
+      if (!isValidCreateRecordingRequestData(request.data)) {
+        throw new Error(`Invalid data provided for recorder:stop request`)
+      }
+
+      try {
+        console.log(
+          '* request.data.storageLocation:',
+          request.data.storageLocation,
+        )
+        await writeFile(
+          path.resolve(request.data.storageLocation, 'test.txt'),
+          'Test-file content',
+          { encoding: 'utf-8' },
+        )
+      } catch (error) {
+        console.error('Could not write file:', error)
+        event.sender.send(this.responseChannel, {
+          success: false,
+        })
+        this.responseChannel = null
+        return
+      }
+
+      event.sender.send(this.responseChannel, {
+        success: true,
+      })
+
+      this.responseChannel = null
+    })
+  }
+}
+
+const isValidCreateRecordingRequestData = (
+  data: unknown,
+): data is {
+  storageLocation: string
+} => {
+  if (
+    typeof data !== 'object' ||
+    data === null ||
+    !('storageLocation' in data) ||
+    typeof data.storageLocation !== 'string'
+  ) {
+    return false
+  }
+  return true
+}

--- a/apps/electron-client/src/index.ts
+++ b/apps/electron-client/src/index.ts
@@ -1,4 +1,8 @@
+import { CreateRecordingChannel } from './channels/CreateRecordingChannel'
 import { OpenDirectoryDialogChannel } from './channels/OpenDirectoryDialogChannel'
 import { MainWindow } from './main'
 
-new MainWindow().init([new OpenDirectoryDialogChannel()])
+new MainWindow().init([
+  new OpenDirectoryDialogChannel(),
+  new CreateRecordingChannel(),
+])

--- a/apps/electron-client/src/preload.ts
+++ b/apps/electron-client/src/preload.ts
@@ -4,7 +4,11 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { ValidIpcChanel } from '@tapes-monorepo/core'
 
-const validChannels: ValidIpcChanel[] = ['storage:open-directory-dialog']
+const validChannels: ValidIpcChanel[] = [
+  'storage:open-directory-dialog',
+  'recorder:start',
+  'recorder:stop',
+]
 
 const validResponseChannels = validChannels.map(
   (channel) => `${channel}:response:.*`,

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -11,7 +11,10 @@ declare global {
   }
 }
 
-export type ValidIpcChanel = 'storage:open-directory-dialog'
+export type ValidIpcChanel =
+  | 'storage:open-directory-dialog'
+  | 'recorder:start'
+  | 'recorder:stop'
 
 type IpcRequest = {
   responseChannel?: string

--- a/packages/core/app/views/Recorder.tsx
+++ b/packages/core/app/views/Recorder.tsx
@@ -20,8 +20,6 @@ export function Recorder() {
     'frequency',
   )
 
-  console.log('audioInputDeviceId:', audioInputDeviceId)
-
   return (
     <>
       <div className="flex h-full flex-col pb-20">
@@ -98,7 +96,25 @@ export function Recorder() {
               <Button
                 title={isRecording ? 'Stop recording' : 'Start recording'}
                 className="group relative flex size-full justify-center p-4 text-xs"
-                onClick={() => setIsRecording(!isRecording)}
+                onClick={() => {
+                  if (appContext.type !== 'electron-client') {
+                    return
+                  }
+
+                  if (!isRecording) {
+                    setIsRecording(true)
+                    appContext.ipc.send('recorder:start', {
+                      data: { storageLocation },
+                    })
+                    return
+                  }
+
+                  if (isRecording) {
+                    setIsRecording(false)
+                    appContext.ipc.send('recorder:stop')
+                    // TODO: Show set recording name dialog
+                  }
+                }}
               >
                 {isRecording && (
                   <div className="absolute right-0 top-0 flex p-2 text-xs text-rose-500">


### PR DESCRIPTION
* Add `CreateRecordingChannel` to handle `recorder:start` and `recorder:stop` events
* Send the events from the `Recorder` view when starting and stopping recording
* Pass `storageLocation` in `data` in `recorder:start` event