### PR TITLE
fix(electron-client): reduce risk of memory leaks from too many IPC listeners

### DIFF
--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -6,7 +6,7 @@
   "main": ".vite/build/index.js",
   "repository": "github:phonofidelic/tapes-monorepo",
   "scripts": {
-    "dev": "dotenvx run --env-file=.env -- electron-forge start",
+    "dev": "dotenvx run --env-file=.env -- electron-forge start -- --trace-warnings",
     "package": "dotenvx run --env-file=.env -- electron-forge package",
     "make": "dotenvx run --env-file=.env -- electron-forge make",
     "publish": "dotenvx run --env-file=.env -- electron-forge publish",

--- a/apps/electron-client/src/main.ts
+++ b/apps/electron-client/src/main.ts
@@ -87,6 +87,8 @@ export class MainWindow {
   }
 
   private registerIpcChannels(ipcChannels: IpcChannel[]) {
+    ipcMain.setMaxListeners(1)
+
     ipcChannels.forEach((channel) =>
       ipcMain.on(channel.name, (event, request) =>
         channel.handle(event, request),

--- a/apps/electron-client/src/renderer.tsx
+++ b/apps/electron-client/src/renderer.tsx
@@ -32,6 +32,7 @@ import {
   App,
   AppContextProvider,
   IpcService,
+  RecordingProvider,
   SettingsProvider,
   ViewProvider,
 } from '@tapes-monorepo/core'
@@ -55,32 +56,34 @@ root.render(
         ipc: new IpcService(),
       }}
     >
-      <ViewProvider>
-        <SettingsProvider>
-          <div
-            style={{
-              position: 'relative',
-              height: '100vh',
-              width: '100vw',
-              userSelect: 'none',
-              paddingTop: '32px',
-            }}
-          >
+      <RecordingProvider>
+        <ViewProvider>
+          <SettingsProvider>
             <div
-              id="titlebar"
               style={{
-                position: 'fixed',
-                top: 0,
-                left: 0,
-                width: '100%',
-                height: '32px',
-                zIndex: 999,
+                position: 'relative',
+                height: '100vh',
+                width: '100vw',
+                userSelect: 'none',
+                paddingTop: '32px',
               }}
-            />
-            <App />
-          </div>
-        </SettingsProvider>
-      </ViewProvider>
+            >
+              <div
+                id="titlebar"
+                style={{
+                  position: 'fixed',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  height: '32px',
+                  zIndex: 999,
+                }}
+              />
+              <App />
+            </div>
+          </SettingsProvider>
+        </ViewProvider>
+      </RecordingProvider>
     </AppContextProvider>
   </StrictMode>,
 )

--- a/apps/web/app/app/page.tsx
+++ b/apps/web/app/app/page.tsx
@@ -3,6 +3,7 @@
 import {
   App,
   AppContextProvider,
+  RecordingProvider,
   SettingsProvider,
   ViewProvider,
 } from '@tapes-monorepo/core'
@@ -13,11 +14,13 @@ export default function AppPage() {
     <>
       <div className="flex sm:hidden">
         <AppContextProvider value={{ type: 'web' }}>
-          <ViewProvider>
-            <SettingsProvider>
-              <App />
-            </SettingsProvider>
-          </ViewProvider>
+          <RecordingProvider>
+            <ViewProvider>
+              <SettingsProvider>
+                <App />
+              </SettingsProvider>
+            </ViewProvider>
+          </RecordingProvider>
         </AppContextProvider>
       </div>
       <div className="mx-auto hidden h-screen w-screen max-w-screen-sm flex-col items-center justify-center gap-16 sm:flex">

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -22,6 +22,16 @@ type IpcRequest = {
   data?: unknown
 }
 
+export type IpcResponse =
+  | {
+      success: false
+      error: Error
+    }
+  | {
+      success: true
+      data: unknown
+    }
+
 export class IpcService {
   private ipcRenderer?: {
     send(channel: ValidIpcChanel, data: any): void

--- a/packages/core/app/context/RecordingContext.tsx
+++ b/packages/core/app/context/RecordingContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState } from 'react'
+
+const RecordingContext = createContext<{
+  isRecording: boolean
+  setIsRecording: (state: boolean) => void
+} | null>(null)
+
+export const RecordingProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
+  const [isRecording, setIsRecording] = useState(false)
+  return (
+    <RecordingContext.Provider
+      value={{
+        isRecording,
+        setIsRecording,
+      }}
+    >
+      {children}
+    </RecordingContext.Provider>
+  )
+}
+
+export function useRecordingState() {
+  const context = useContext(RecordingContext)
+  if (context === null) {
+    throw new Error('useRecordingState must be used within a RecordingProvider')
+  }
+  return context
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,5 +1,6 @@
 export * from './app/App'
 export * from './app/context/AppContext'
+export * from './app/context/RecordingContext'
 export * from './app/context/ViewContext'
 export * from './app/context/SettingsContext'
 export * from './app/views/Recorder'


### PR DESCRIPTION
* Reduce the risk of memory leaks in the Electron client by restricting the number of listeners for each IPC (Inter-Process Communication) event to 1.
* Use `ipcMain.once` to register `recorder:stop` handler in `CreateRecordingChannel`.
* Add `RecordingContext` to hold `isRecording` state when changing views during recording.
* Add initial error handling in `CreateRecordingChannel` and placeholder error logs in `Recorder` view.