### PR TITLE
feat(core): add create new recording UI

### DIFF
--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -25,11 +25,25 @@ type IpcRequest = {
 export type IpcResponse =
   | {
       success: false
+      data: never
       error: Error
     }
   | {
       success: true
       data: unknown
+      error: never
+    }
+
+export type StopRecordingResponse =
+  | {
+      success: false
+      data: never
+      error: Error
+    }
+  | {
+      success: true
+      data: { filepath: string }
+      error: never
     }
 
 export class IpcService {


### PR DESCRIPTION
Adds initial UI for creating a new recording:
<img width="520" alt="create new recording UI" src="https://github.com/user-attachments/assets/b254dad5-f741-4d83-b1e9-3702b2fc4bbc" />

* Clicking the record button starts recording
* Clicking the record button again stops recording and brings up new recording UI
* Cancel button to discard the new recording
* Edit button to rename the new recording
* Checkmark button to save changes 