### PR TITLE
feat(electron-client): add `storage:edit-recording` channel

### DIFF
--- a/apps/electron-client/src/channels/CreateRecordingChannel.ts
+++ b/apps/electron-client/src/channels/CreateRecordingChannel.ts
@@ -1,4 +1,5 @@
 import path from 'path'
+import crypto from 'crypto'
 import { writeFile } from 'fs/promises'
 import { ipcMain, IpcMainEvent } from 'electron'
 import { IpcChannel, IpcRequest } from '@/types'
@@ -9,7 +10,7 @@ export class CreateRecordingChannel implements IpcChannel {
   async handle(event: IpcMainEvent, request: IpcRequest) {
     const { responseChannel } = request
     if (!responseChannel) {
-      throw new Error(`No response channel provided for recorder:start request`)
+      throw new Error(`No response channel provided for ${this.name} request`)
     }
 
     ipcMain.once('recorder:stop', this.onRecorderStop.bind(this))
@@ -29,7 +30,10 @@ export class CreateRecordingChannel implements IpcChannel {
       throw new Error(`Invalid data provided for recorder:stop request`)
     }
 
-    const filepath = path.resolve(request.data.storageLocation, 'test.txt')
+    const filepath = path.resolve(
+      request.data.storageLocation,
+      `${crypto.randomUUID()}.txt`,
+    )
 
     const centiseconds = (
       '0' +

--- a/apps/electron-client/src/channels/EditRecordingChannel.ts
+++ b/apps/electron-client/src/channels/EditRecordingChannel.ts
@@ -1,0 +1,51 @@
+import path from 'path'
+import { rename } from 'fs/promises'
+import { IpcMainEvent } from 'electron'
+import { IpcChannel, IpcRequest } from '@/types'
+
+export class EditRecordingChannel implements IpcChannel {
+  name = 'storage:edit-recording'
+
+  async handle(event: IpcMainEvent, request: IpcRequest) {
+    const { responseChannel, data } = request
+    if (!responseChannel) {
+      throw new Error(`No response channel provided for recorder:start request`)
+    }
+
+    if (!isValidEditRecordingRequestData(data)) {
+      throw new Error(`No response channel provided for ${this.name} request`)
+    }
+
+    const { filename, filepath } = data
+
+    try {
+      const newPath = path.join(
+        path.dirname(filepath),
+        filename + path.extname(filepath),
+      )
+      await rename(filepath, newPath)
+      event.sender.send(responseChannel, { success: true })
+    } catch (error) {
+      event.sender.send(responseChannel, {
+        success: false,
+        error: new Error('Could not rename file'),
+      })
+    }
+  }
+}
+
+const isValidEditRecordingRequestData = (
+  data: unknown,
+): data is {
+  filename: string
+  filepath: string
+} => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'filename' in data &&
+    'filepath' in data &&
+    typeof data.filename === 'string' &&
+    typeof data.filepath === 'string'
+  )
+}

--- a/apps/electron-client/src/index.ts
+++ b/apps/electron-client/src/index.ts
@@ -1,8 +1,10 @@
 import { CreateRecordingChannel } from './channels/CreateRecordingChannel'
+import { EditRecordingChannel } from './channels/EditRecordingChannel'
 import { OpenDirectoryDialogChannel } from './channels/OpenDirectoryDialogChannel'
 import { MainWindow } from './main'
 
 new MainWindow().init([
   new OpenDirectoryDialogChannel(),
   new CreateRecordingChannel(),
+  new EditRecordingChannel(),
 ])

--- a/apps/electron-client/src/preload.ts
+++ b/apps/electron-client/src/preload.ts
@@ -6,6 +6,7 @@ import { ValidIpcChanel } from '@tapes-monorepo/core'
 
 const validChannels: ValidIpcChanel[] = [
   'storage:open-directory-dialog',
+  'storage:edit-recording',
   'recorder:start',
   'recorder:stop',
 ]

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -13,6 +13,7 @@ declare global {
 
 export type ValidIpcChanel =
   | 'storage:open-directory-dialog'
+  | 'storage:edit-recording'
   | 'recorder:start'
   | 'recorder:stop'
 

--- a/packages/core/app/views/Recorder.tsx
+++ b/packages/core/app/views/Recorder.tsx
@@ -41,9 +41,12 @@ export function Recorder() {
 
     console.log('TODO: commit file change', { filename, filepath })
     // TODO: edit recording filename
-    // appContext.ipc.send('rename-recording', {
-    //   filename
-    // })
+    appContext.ipc.send('storage:edit-recording', {
+      data: {
+        filename,
+        filepath,
+      },
+    })
     setIsEditing(false)
     setIsEditorOpen(false)
   }


### PR DESCRIPTION
Adds a new channel for editing a recording's filename.

* Adds temporary random filename for newly created recording
* Adds initial client-side validation of user input filename
* The file is re-named to user input