### PR TITLE
fix(electron-client): don't edit filename on recording creation

### DIFF
--- a/apps/electron-client/src/channels/EditRecordingChannel.ts
+++ b/apps/electron-client/src/channels/EditRecordingChannel.ts
@@ -29,6 +29,7 @@ export class EditRecordingChannel implements IpcChannel {
         data: { filepath: newPath },
       })
     } catch (error) {
+      console.error(error)
       event.sender.send(responseChannel, {
         success: false,
         error: new Error('Could not rename file'),

--- a/packages/core/app/views/Library.tsx
+++ b/packages/core/app/views/Library.tsx
@@ -325,7 +325,7 @@ function Editor({
           <MdCheck />
         </Button>
       </div>
-      <div className="flex w-fit flex-col gap-2 text-xs">
+      <div className="flex w-full flex-col gap-2 text-xs">
         <EditableText
           text={recording.filename}
           inputType="text"
@@ -448,7 +448,7 @@ function EditableText({
   }
 
   return isEditing ? (
-    <div className="flex flex-col justify-center">
+    <div className="flex w-full flex-col justify-center">
       <label
         htmlFor={id}
         className={clsx(


### PR DESCRIPTION
The user-entered recording name is only used for the display name when creating a new recording. The randomly generated filename can still be changed from the Library view.