### PR TITLE
fix(electron-client): add media-src directive to Content-Security-Policy

### DIFF
--- a/apps/electron-client/index.html
+++ b/apps/electron-client/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'sha256-n94KK341T3wquqTA6Wx/qa09QixHMM7XPopBCzn9FA8='; script-src-elem 'self' 'wasm-unsafe-eval'; script-src 'wasm-unsafe-eval'; connect-src *" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; media-src http://localhost:* tapes:; style-src 'sha256-n94KK341T3wquqTA6Wx/qa09QixHMM7XPopBCzn9FA8='; script-src-elem 'self' 'wasm-unsafe-eval'; script-src 'wasm-unsafe-eval'; connect-src *" />
     <title>Tapes</title>
     <script type="module" src="/src/renderer.tsx"></script>
   </head>


### PR DESCRIPTION
Was getting an error when trying to play recordings from the electron client. There was no `media-src` directive set in the Content-Security-Policy.

Docs: https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP#csp_overview