### PR TITLE
fix: await repo.find() per automerge-repo v2 async API

### DIFF
--- a/packages/core/app/App.tsx
+++ b/packages/core/app/App.tsx
@@ -56,7 +56,7 @@ export function App({
       })
 
       if (automergeUrl && isValidAutomergeUrl(automergeUrl)) {
-        handleRef.current = _repo.find(automergeUrl)
+        handleRef.current = await _repo.find(automergeUrl)
       } else {
         handleRef.current = _repo.create<RecordingRepoState>({ recordings: [] })
         setAutomergeUrl(handleRef.current.url)


### PR DESCRIPTION
automerge-repo v2 made `Repo.find()` async; `App.tsx` still assigned the returned promise to `handleRef`. Caught by `check-types` while verifying the automerge v2 companion updates (#201–#205) — CI doesn't run check-types, so it slipped past #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)