### PR TITLE
chore: hold typescript 7, tailwind 4, and vite-stack majors in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,39 @@
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["major"],
       "automerge": false
+    },
+    {
+      "description": "Hold TypeScript 7 (tsgo) until Nest, typescript-eslint, and api-extractor support it",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    },
+    {
+      "description": "Hold tailwindcss 4 until the CSS-first config migration lands",
+      "matchPackageNames": ["tailwindcss"],
+      "allowedVersions": "<4"
+    },
+    {
+      "description": "Group vite stack updates into a single PR",
+      "matchPackageNames": [
+        "vite",
+        "@vitejs/plugin-react",
+        "vite-plugin-dts",
+        "vite-plugin-wasm",
+        "vite-plugin-top-level-await"
+      ],
+      "groupName": "vite stack"
+    },
+    {
+      "description": "Hold vite stack majors until the vite 8 migration branch lands",
+      "matchPackageNames": [
+        "vite",
+        "@vitejs/plugin-react",
+        "vite-plugin-dts",
+        "vite-plugin-wasm",
+        "vite-plugin-top-level-await"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Follow-up to today's Renovate triage:

- `typescript` held at `<7` — TS 7 is the tsgo rewrite; Nest, typescript-eslint, and api-extractor (via vite-plugin-dts) aren't ready, and Renovate couldn't even update the lockfile (#195).
- `tailwindcss` held at `<4` — v4 needs the CSS-first config migration across ui/core/web-client/electron-client/tailwind-config (#207).
- vite stack (`vite`, `@vitejs/plugin-react`, `vite-plugin-dts`, `vite-plugin-wasm`, `vite-plugin-top-level-await`) grouped into one PR, with majors disabled until the coordinated vite 8 migration lands (#196, #197, and previously #189).

Tracking issues for the migrations follow; the holds get lifted by deleting these rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)