### PR TITLE
fix(electron-client): harden renderer CSP style-src

### DIFF
--- a/apps/electron-client/index.html
+++ b/apps/electron-client/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; media-src http://localhost:* tapes:; style-src 'sha256-mXhGc1Yb6TojbFQY13CSYOSYdA8cWFG3xeEI0hDwTmo='; script-src-elem 'self' 'wasm-unsafe-eval'; script-src 'wasm-unsafe-eval'; connect-src *" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; media-src http://localhost:* tapes:; style-src 'self'; script-src-elem 'self' 'wasm-unsafe-eval'; script-src 'wasm-unsafe-eval'; connect-src *" />
     <title>Tapes</title>
     <script type="module" src="/src/renderer.tsx"></script>
   </head>

--- a/apps/electron-client/vite.renderer.config.ts
+++ b/apps/electron-client/vite.renderer.config.ts
@@ -1,8 +1,20 @@
 import path from 'path'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import wasm from 'vite-plugin-wasm'
 import topLevelAwait from 'vite-plugin-top-level-await'
+
+// Vite's dev server injects CSS updates via inline <style> tags for HMR,
+// which the production style-src 'self' CSP would block. Relax it for dev only.
+function devCspAllowInlineStyles(): Plugin {
+  return {
+    name: 'dev-csp-allow-inline-styles',
+    apply: 'serve',
+    transformIndexHtml(html) {
+      return html.replace("style-src 'self'", "style-src 'self' 'unsafe-inline'")
+    },
+  }
+}
 
 // https://vitejs.dev/config
 export default defineConfig({
@@ -22,5 +34,5 @@ export default defineConfig({
       ),
     },
   },
-  plugins: [react(), wasm(), topLevelAwait()],
+  plugins: [react(), wasm(), topLevelAwait(), devCspAllowInlineStyles()],
 })


### PR DESCRIPTION
## Summary
Hardens the Electron renderer's Content Security Policy around `style-src`.

- **`apps/electron-client/index.html`** — tightens `style-src` from a specific inline-style hash (`'sha256-…'`) to `'self'`, so production only loads stylesheets from the app origin.
- **`apps/electron-client/vite.renderer.config.ts`** — adds a dev-only Vite plugin (`devCspAllowInlineStyles`, `apply: 'serve'`) that relaxes `style-src 'self'` to also allow `'unsafe-inline'` during development, since Vite's HMR injects CSS via inline `<style>` tags that the production CSP would otherwise block.

Net effect: production runs the strict `'self'` policy while local dev keeps working with HMR.

## Verification
- Prod build serves styles under the strict policy without CSP violations.
- `vite dev` renders styles and hot-reloads CSS without CSP errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)