### PR TITLE
fix: clear low-risk lint warnings (#218 batch 1)

### DIFF
--- a/apps/api/src/sync/sync.gateway.ts
+++ b/apps/api/src/sync/sync.gateway.ts
@@ -22,8 +22,6 @@ export class SyncGateway
 
   @WebSocketServer()
   server: Server
-  readyResolvers: ((value: any) => void)[] = []
-  isReady = false
   repo: Repo
 
   afterInit() {
@@ -36,18 +34,7 @@ export class SyncGateway
       peerId: `storage-server-test`,
       sharePolicy: async () => false,
     })
-    this.isReady = true
     this.logger.log('Initialized')
-  }
-
-  async ready() {
-    if (this.isReady) {
-      return true
-    }
-
-    return new Promise((resolve) => {
-      this.readyResolvers.push(resolve)
-    })
   }
 
   handleConnection() {

--- a/apps/web-client/src/worker.ts
+++ b/apps/web-client/src/worker.ts
@@ -32,7 +32,9 @@ type EventData =
       }
     }
 
-const ctx: DedicatedWorkerGlobalScope = self as any
+// `self` is typed as the base WorkerGlobalScope; assert to the augmented
+// DedicatedWorkerGlobalScope (with fileHandle/accessHandle) declared above.
+const ctx: DedicatedWorkerGlobalScope = self as unknown as DedicatedWorkerGlobalScope
 ctx.fileHandle = null
 ctx.accessHandle = null
 

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -5,8 +5,8 @@
 declare global {
   interface Window {
     api: {
-      send(channel: string, data: any): void
-      receive(channel: string, data: any): void
+      send(channel: ValidIpcChanel, data: IpcRequest): void
+      receive(channel: string, func: (...args: unknown[]) => void): void
     }
   }
 }
@@ -84,10 +84,7 @@ type IpcSendArgs =
     ]
   | ['recorder:stop', IpcRequest]
 export class IpcService {
-  private ipcRenderer?: {
-    send(channel: ValidIpcChanel, data: any): void
-    receive(channel: string, data: any): void
-  }
+  private ipcRenderer?: Window['api']
 
   private initializeIpcRenderer() {
     if (!window || !window.api) {
@@ -124,8 +121,8 @@ export class IpcService {
 
     // This method returns a promise which will be resolved when the response has arrived.
     return new Promise((resolve) => {
-      ipcRenderer.receive(request.responseChannel ?? '', (response: any) => {
-        resolve(response)
+      ipcRenderer.receive(request.responseChannel ?? '', (...args: unknown[]) => {
+        resolve(args[0] as T)
       })
     })
   }

--- a/packages/core/app/components/AudioVisualizer.tsx
+++ b/packages/core/app/components/AudioVisualizer.tsx
@@ -50,7 +50,7 @@ export function AudioVisualizer({
     return () => {
       window.removeEventListener('resize', onResize)
     }
-  }, [])
+  }, [containerRef])
 
   useEffect(() => {
     if (!canvasRef.current) {
@@ -125,7 +125,7 @@ const draw = ({
   canvasWidth,
   canvasHeight,
 }: {
-  dataArray: Uint8Array | []
+  dataArray: Uint8Array
   feature: 'frequency' | 'time-domain'
   theme: 'dark' | 'light'
   ctx: CanvasRenderingContext2D
@@ -140,7 +140,7 @@ const draw = ({
 
   const drawAverage = () => {
     // Draw average
-    const sum = (dataArray as any[]).reduce((a: number, b: number) => a + b)
+    const sum = dataArray.reduce((a: number, b: number) => a + b, 0)
     const average = sum / dataArray.length || 0
     ctx.strokeStyle = theme === 'dark' ? '#a1a1aa' : '#a1a1aa'
     if (average >= 128) {

--- a/packages/core/app/context/AudioPlayerContext.tsx
+++ b/packages/core/app/context/AudioPlayerContext.tsx
@@ -80,7 +80,7 @@ export const AudioPlayerProvider = ({
         appContext.worker.removeEventListener('message', onMessage)
       }
     }
-  }, [currentSource])
+  }, [currentSource, appContext])
 
   useEffect(() => {
     const audio = audioRef.current


### PR DESCRIPTION
First of several PRs resolving the deferred lint warnings tracked in #218. This batch is the provably-safe subset: **10 of the 17 warnings cleared, no runtime behavior change.**

## Changes

| File | Change | Cleared |
|------|--------|---------|
| `sync.gateway.ts` | Delete dead `ready()` / `readyResolvers` / `isReady` | 1 `no-explicit-any` |
| `IpcService.ts` | Type the `window.api` bridge to preload's real signatures | 5 `no-explicit-any` |
| `worker.ts` | `self as unknown as DedicatedWorkerGlobalScope` | 1 `no-explicit-any` |
| `AudioVisualizer.tsx` | Drop vestigial `\| []` (removes `as any[]`); add `containerRef` dep | 1 `no-explicit-any`, 1 `exhaustive-deps` |
| `AudioPlayerContext.tsx` | Add stable `appContext` dep | 1 `exhaustive-deps` |

## Notes

- **`sync.gateway.ts`** — `ready()` was dead *and* broken: `afterInit()` set `isReady = true` but never drained `readyResolvers`, and nothing calls `ready()`, so any pre-init call would hang forever. Deleted rather than typed.
- **`IpcService.ts`** — the `any` was concealing a real signature error: the bridge declared `receive(channel, data)` but every caller and the preload implementation pass a *callback*. Typing it correctly (`func: (...args: unknown[]) => void`) means `check-types` now enforces the contract. The response callback resolves `args[0] as T` — an explicit cast at the IPC trust boundary; a validating guard is noted as a possible follow-up.

## Verification

- `turbo check-types lint build` green across all 16 workspace tasks.
- `sync.gateway.spec.ts` still fails to *run*, but that is the pre-existing ESM/automerge type-resolution issue tracked in #216 — reproduced identically on `main`. The 2 real tests pass.

## Deferred to follow-up PRs

The remaining 7 warnings change behavior and require manual recording verification: the RecordingContext refs redesign, the device-switch `exhaustive-deps` effects (which fix real stale-closure bugs), and finally deleting the `no-explicit-any` override in `base.js` so the rule returns to `error`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)