### PR TITLE
fix: react to input-device changes in AudioVisualizer + close the audio graph (#218)

### DIFF
--- a/packages/core/app/components/AudioVisualizer.tsx
+++ b/packages/core/app/components/AudioVisualizer.tsx
@@ -59,15 +59,25 @@ export function AudioVisualizer({
 
     const canvas = canvasRef.current
     const ctx = canvas.getContext('2d')
-    const audioContext = new AudioContext()
-    let rafId: number
 
     if (!ctx) {
       return
     }
 
+    const audioContext = new AudioContext()
+    let rafId: number
+    let stream: MediaStream | undefined
+    let cancelled = false
+
     getAudioStream(audioInputDeviceId)
-      .then((stream) => {
+      .then((mediaStream) => {
+        // getAudioStream is async; the effect may have been torn down (device
+        // change, unmount) before it resolved. Don't start a second graph.
+        if (cancelled) {
+          mediaStream.getTracks().forEach((track) => track.stop())
+          return
+        }
+        stream = mediaStream
         const source = audioContext.createMediaStreamSource(stream)
         const analyser = audioContext.createAnalyser()
         analyser.fftSize = 128
@@ -101,9 +111,12 @@ export function AudioVisualizer({
       })
 
     return () => {
+      cancelled = true
       cancelAnimationFrame(rafId)
+      stream?.getTracks().forEach((track) => track.stop())
+      audioContext.close().catch(() => {})
     }
-  }, [feature, theme])
+  }, [audioInputDeviceId, feature, theme])
 
   return (
     <canvas


### PR DESCRIPTION
Part of #218 (the device-switch `exhaustive-deps` fixes). **Behavior-changing — needs manual verification before merge (see below).**

## The bug

`AudioVisualizer`'s audio effect ran on `[feature, theme]` but read `audioInputDeviceId` from props. Switching the input device never re-ran the effect, so the visualizer kept rendering the **previously selected mic**. Adding `audioInputDeviceId` to the deps fixes it.

## Why it's not a one-line dep add

Adding the dep alone would amplify a pre-existing leak: the cleanup only did `cancelAnimationFrame` — it never closed the `AudioContext` or stopped the stream tracks, and Chrome caps concurrent `AudioContext`s. More re-runs would turn a slow leak into a hard failure. So this also:

- closes the `AudioContext` and stops the stream tracks on teardown;
- adds a `cancelled` guard so a stream that resolves *after* teardown (device change / unmount) doesn't start an orphan `requestAnimationFrame` loop;
- moves `new AudioContext()` after the 2d-context guard so it can't leak when context acquisition fails.

## Verification

- ✅ `turbo check-types lint` — the `audioInputDeviceId` warning is gone, no new errors.
- ⚠️ **Manual, required:** open web-client, start the visualizer, switch the audio input device, and confirm the visualizer follows the **new** mic. There is no automated coverage for this (`packages/core` has no test infra — see #222).

🤖 Generated with [Claude Code](https://claude.com/claude-code)