### PR TITLE
fix: resolve remaining exhaustive-deps warnings (#218)

### DIFF
--- a/packages/core/app/App.tsx
+++ b/packages/core/app/App.tsx
@@ -16,7 +16,7 @@ import { AudioPlayer } from './components/AudioPlayer'
 import { useAudioPlayer } from './context/AudioPlayerContext'
 import Providers from './context/Providers'
 import { AppContextValue } from './context/AppContext'
-import { useAutomergeUrl } from './utils'
+import { setAutomergeUrl, useAutomergeUrl } from './utils'
 
 export function App({
   appContextValue,
@@ -25,10 +25,11 @@ export function App({
   appContextValue: AppContextValue
   syncServerUrl: string
 }) {
-  const { automergeUrl, setAutomergeUrl } = useAutomergeUrl()
+  const { automergeUrl } = useAutomergeUrl()
   const [repo, setRepo] = useState<Repo | null>(null)
   const mainRef = useRef<HTMLDivElement | null>(null)
   const handleRef = useRef<DocHandle<unknown> | null>(null)
+  const didInitRef = useRef(false)
 
   useEffect(() => {
     // const onEphemeralMessage = (message: any) => {
@@ -36,9 +37,13 @@ export function App({
     // }
 
     const initialize = async () => {
-      if (repo) {
+      // Guard against re-init (StrictMode double-invoke, dep changes). A `repo`
+      // state check can't do this: initialize() is async and setRepo lands only
+      // at the end, so concurrent runs would each build a Repo and websocket.
+      if (didInitRef.current) {
         return
       }
+      didInitRef.current = true
 
       // const broadcast = new BroadcastChannelNetworkAdapter()
       // TODO: Set up sync server
@@ -74,7 +79,7 @@ export function App({
     //     handleRef.current.off('ephemeral-message', onEphemeralMessage)
     //   }
     // }
-  }, [])
+  }, [automergeUrl, syncServerUrl])
 
   if (!repo) {
     return <div>Loading...</div>

--- a/packages/core/app/context/AudioPlayerContext.tsx
+++ b/packages/core/app/context/AudioPlayerContext.tsx
@@ -35,6 +35,9 @@ export const AudioPlayerProvider = ({
   )
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
+  // Mirrors `duration` so `onEnded` can read the latest value without the
+  // audio effect re-running (and calling audio.load()) whenever it changes.
+  const durationRef = useRef(0)
   const [isPlaying, setIsPlaying] = useState(false)
   const [clickedTime, setClickedTime] = useState(0)
 
@@ -87,9 +90,10 @@ export const AudioPlayerProvider = ({
     audio.load()
 
     const onLoadedMetadata = () => {
-      setDuration(
-        audio.duration / (appContext.type === 'electron-client' ? 1000 : 1),
-      )
+      const scaledDuration =
+        audio.duration / (appContext.type === 'electron-client' ? 1000 : 1)
+      durationRef.current = scaledDuration
+      setDuration(scaledDuration)
     }
 
     const onCanPlay = async () => {
@@ -106,7 +110,7 @@ export const AudioPlayerProvider = ({
       audio.pause()
       setIsPlaying(false)
       setCurrentTime(0)
-      audio.currentTime = duration
+      audio.currentTime = durationRef.current
     }
 
     const onError = () => {
@@ -126,7 +130,7 @@ export const AudioPlayerProvider = ({
       audio.removeEventListener('ended', onEnded)
       audio.removeEventListener('error', onError)
     }
-  }, [isPlaying])
+  }, [isPlaying, appContext.type])
 
   return (
     <AudioPlayerContext.Provider

--- a/packages/core/app/utils.ts
+++ b/packages/core/app/utils.ts
@@ -12,14 +12,14 @@ export const getAudioStream = async (selectedMediaDeviceId: string) => {
   return audioStream
 }
 
+export function setAutomergeUrl(url: string) {
+  localStorage.setItem('automergeUrl', url)
+}
+
 export function useAutomergeUrl() {
   const automergeUrl =
     new URLSearchParams(window.location.search).get('am') ??
     localStorage.getItem('automergeUrl')
-
-  const setAutomergeUrl = (url: string) => {
-    localStorage.setItem('automergeUrl', url)
-  }
 
   return { automergeUrl, setAutomergeUrl }
 }

--- a/packages/core/app/views/Library.tsx
+++ b/packages/core/app/views/Library.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import { AutomergeUrl, isValidAutomergeUrl } from '@automerge/automerge-repo'
 import { useDocument } from '@automerge/automerge-repo-react-hooks'
@@ -25,6 +25,7 @@ export function Library() {
   const { currentUrl } = useAudioPlayer()
 
   const [editingUrl, setEditingUrl] = useState<AutomergeUrl | null>(null)
+  const handleCloseEditor = useCallback(() => setEditingUrl(null), [])
 
   const deleteRecording = (url: AutomergeUrl) => {
     changeDocState((doc) => {
@@ -63,12 +64,12 @@ export function Library() {
           },
         )}
       >
-        <Editor automergeUrl={editingUrl} onClose={() => setEditingUrl(null)} />
+        <Editor automergeUrl={editingUrl} onClose={handleCloseEditor} />
       </div>
       <Backdrop
         title="Close editor"
         isOpen={editingUrl !== null}
-        onClose={() => setEditingUrl(null)}
+        onClose={handleCloseEditor}
       />
     </>
   )
@@ -91,6 +92,7 @@ function LibraryListItem({
   const previousRecordingName = useRef(recording?.name)
 
   const [isOptionsMenuOpen, setIsOptionsMenuOpen] = useState(false)
+  const handleCloseMenu = useCallback(() => setIsOptionsMenuOpen(false), [])
   const [, setEditedName] = useState(recording?.name)
 
   useEffect(() => {
@@ -228,7 +230,7 @@ function LibraryListItem({
       <Backdrop
         title="Close menu"
         isOpen={isOptionsMenuOpen}
-        onClose={() => setIsOptionsMenuOpen(false)}
+        onClose={handleCloseMenu}
       />
     </>
   )
@@ -496,6 +498,9 @@ function Backdrop({
   onClose: () => void
 }) {
   useEffect(() => {
+    if (!isOpen) {
+      return
+    }
     const onEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         onClose()
@@ -506,7 +511,7 @@ function Backdrop({
     return () => {
       document.removeEventListener('keydown', onEscape)
     }
-  }, [])
+  }, [isOpen, onClose])
 
   return (
     <button

--- a/packages/core/app/views/Recorder.tsx
+++ b/packages/core/app/views/Recorder.tsx
@@ -394,7 +394,7 @@ function useMonitor(selectedMediaDeviceId: string | undefined) {
     return () => {
       audioCtx.close()
     }
-  }, [isMonitoring])
+  }, [isMonitoring, selectedMediaDeviceId])
 
   return {
     isMonitoring,


### PR DESCRIPTION
The remaining 4 `react-hooks/exhaustive-deps` sites from #218 — the ones needing real refactors rather than a dep add. ⚠️ **Behavior-changing — needs manual verification (see below).**

## Changes

- **`App.tsx` repo init** — hoist `setAutomergeUrl` to module scope in `utils.ts` (it closes over nothing → stable reference), and replace the `if (repo) return` guard with a `didInitRef`. The state guard couldn't actually prevent duplicate init: `initialize()` is async and `setRepo` lands only at the end, so concurrent runs (StrictMode double-invoke, dep changes) each built a `Repo` **and a websocket connection**. Effect now depends on `[automergeUrl, syncServerUrl]`. `useAutomergeUrl` still returns `{ automergeUrl, setAutomergeUrl }`, so `Settings.tsx` is unaffected.
- **`AudioPlayerContext`** — mirror `duration` into a ref read by `onEnded`, so the audio effect no longer re-runs (and re-calls `audio.load()`, resetting playback) whenever duration changes. Add the stable `appContext.type`.
- **`Library` Backdrop** — wrap the two `onClose` handlers in `useCallback` so the Escape-key effect can depend on `onClose` without re-registering every render, and **gate the effect on `isOpen`**: it previously registered the keydown listener unconditionally, so Escape fired `onClose()` even while the backdrop was closed.
- **`Recorder` `useMonitor`** — add `selectedMediaDeviceId`, so switching the input device while monitoring uses the new device instead of the mount-time one.

## Verification

- ✅ `turbo check-types lint` — all four warnings gone, no new errors.
- ⚠️ **Manual, recommended** (no automated coverage — see #222):
  - Switch input device while monitoring → new device is heard.
  - Audio playback doesn't stutter/reset mid-play.
  - Escape closes an **open** backdrop and does nothing when closed.
  - App still boots and connects to sync exactly once (no duplicate websockets in the network panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)