### PR TITLE
fix: enforce no-explicit-any as an error (#218)

### DIFF
--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -18,11 +18,6 @@ export const config = [
     },
     rules: {
       "turbo/no-undeclared-env-vars": "warn",
-      // Advisory, not blocking: a backlog of pre-existing violations that each
-      // need per-site judgement to type properly. Visible, but not a CI gate.
-      // Remove this override once #218 clears them. (react-hooks/exhaustive-deps
-      // is likewise advisory, but ships as "warn" upstream and needs no override.)
-      "@typescript-eslint/no-explicit-any": "warn",
     },
   },
   {


### PR DESCRIPTION
## What

Deletes the `@typescript-eslint/no-explicit-any` severity override in `packages/eslint-config/base.js`. The rule now reports at its real upstream `error` severity, so any new `any` in source fails CI.

## Why

The override was a deliberate, temporary escape hatch (see [[lint-gate-severity-model]] / issue #218): the rule ships as `error` upstream but was demoted to `warn` so a backlog of pre-existing violations wouldn't break the build. That backlog has now been cleared:

- **#221** — sync.gateway / IpcService / worker / AudioVisualizer `any` sites
- **#228** — RecordingContext redesign, clearing the last `any` + the `react-hooks/refs` disables

All of those are merged to `main`, so the override is the only thing still keeping the rule non-blocking. This removes it — the final step of #218.

## Verification

`turbo lint --force` — all 7 lint tasks pass with the rule at `error`. Confirmed no remaining `any` in linted source (remaining matches are in generated `.next/types/**`, which is ignored, and in comments).

This is the last PR in the #218 series (batch 1 #221, device dep #227, RecordingContext #228, exhaustive-deps #229 all merged).

Closes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)