### PR TITLE
fix(api): set rootDir in tsconfig.build.json (TS5011)

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src"
+  },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Problem

`nest build` in `apps/api` fails under TypeScript 6.0.3 (bumped in the vite-8 migration):

```
error TS5011: The common source directory of 'tsconfig.build.json' is './src'.
The 'rootDir' setting must be explicitly set to this or another path...
```

## Why it regressed

`rootDir: "./src"` used to live in the base `tsconfig.json`, but was removed in 6aa64dc: that config has no `include`, so it also pulls in `test/` (e2e specs) which sits outside `./src`, triggering TS6059. Removing it fixed the editor/check-types path but left `nest build` (which runs through `tsconfig.build.json`) hitting TS5011 under the new TS 6.

## Fix

Set `rootDir: "./src"` in `tsconfig.build.json` **only**. That config already excludes `test/` and `**/*spec.ts`, so `./src` is genuinely the common source dir there — no conflict. The base `tsconfig.json` stays `rootDir`-free so the editor and `check-types` still see `test/`.

Bonus: output now flattens to `dist/main.js` (was `dist/src/main.js`), matching where `nest start` looks.

## Verification

- `yarn build` (api) — passes, no TS5011; `dist/main.js` at top level, no `dist/src/` nesting
- `yarn check-types` (api, base config incl. `test/`) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)