### PR TITLE
fix(api): make jest run under ESM-only automerge-repo v2

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -70,8 +70,20 @@
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
+      "^.+\\.(t|j)s$": [
+        "ts-jest",
+        {
+          "diagnostics": {
+            "ignoreCodes": [
+              2578
+            ]
+          }
+        }
+      ]
     },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!@automerge/automerge-repo)"
+    ],
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -15,6 +15,10 @@ describe('AppController (e2e)', () => {
     await app.init();
   });
 
+  afterEach(async () => {
+    await app.close();
+  });
+
   it('/ (GET)', () => {
     return request(app.getHttpServer())
       .get('/')

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -4,6 +4,7 @@
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
+    "^.+\\.(t|j)s$": ["ts-jest", { "diagnostics": { "ignoreCodes": [2578] } }]
+  },
+  "transformIgnorePatterns": ["/node_modules/(?!@automerge/automerge-repo)"]
 }


### PR DESCRIPTION
## Problem

Both api test suites (`yarn test`, `yarn test:e2e`) fail to run. It looks like missing test deps, but everything is installed — the suites can't **compile/load**. This has been broken since the automerge v1→v2 bump and went unnoticed because **CI runs only `lint`/`check-types`/`build`, never the tests**.

## Three layered causes

1. **ESM-only dependency.** `@automerge/automerge-repo@2` ships ESM only (`"type": "module"`, no CommonJS `require` export condition). Jest's default CommonJS runtime can't load it → `SyntaxError: Unexpected token 'export'`.
   → Narrow `transformIgnorePatterns` so `ts-jest` transpiles the `@automerge/automerge-repo*` packages to CJS. The WASM core `@automerge/automerge` has a CJS build and resolves on its own, so it stays ignored.

2. **tsc vs ts-jest disagree on a suppression.** With the ESM issue fixed, `ts-jest` reports the network-adapter `@ts-expect-error` in `sync.gateway.ts` as unused (`TS2578`) — but workspace `tsc` (both `check-types` and `nest build`) *requires* it (`TS2740`: `WebSocketServerAdapter` isn't assignable to `NetworkAdapterInterface`). They resolve automerge's adapter types differently.
   → Rather than weaken the source (breaks the build) or change `moduleResolution` (the ESM runtime on Node 24 depends on the current setting), tell `ts-jest` to ignore diagnostic `2578`. Workspace `tsc` remains the authority on unused suppressions.

3. **Leaked open handles.** The e2e spec calls `app.init()` but never `app.close()`, so the gateway's WS server (port 433) + FS storage stay open and Jest hangs after the test ("Jest did not exit…").
   → Add an `afterEach(() => app.close())`. Cleaner than `--forceExit`.

## Verification (in-worktree)

| gate | result |
|------|--------|
| `yarn lint` (api) | ✅ exit 0 |
| `yarn check-types` (api) | ✅ exit 0 |
| `yarn build` (api) | ✅ exit 0 |
| `yarn test` (unit) | ✅ 3/3 |
| `yarn test:e2e` | ✅ 1/1, exits cleanly (no open-handle hang) |

Scoped to `apps/api` test config + the e2e spec; no source/runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)