### PR TITLE
fix(api): make check-types TS 6-ready (jest globals + supertest)

### DIFF
--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import * as request from 'supertest';
+// supertest is a CommonJS `export =` module; `import = require` keeps it
+// callable under TS 6 without enabling esModuleInterop (which breaks the
+// ts-jest transpilation of automerge-repo's ESM at runtime).
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import request = require('supertest');
 import { AppModule } from './../src/app.module';
 
 describe('AppController (e2e)', () => {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -12,6 +12,7 @@
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
+    "types": ["node", "jest"],
     "strictNullChecks": true,
     "noImplicitAny": true,
     "strictBindCallApply": true,


### PR DESCRIPTION
## Purpose

Prep `main` for the **TypeScript v6** bump in #237. #237 currently fails CI at `api#check-types` — under TS 6, `tsc --noEmit` strictly type-checks the api test files and hits errors TS 5.9 tolerated. This PR lands the two fixes that are **safe under the current TS 5.9**, so main stays green and #237 goes green on rebase.

## What breaks under TS 6 (and the fix here)

1. **Jest ambient globals go missing** — `TS2593 Cannot find name 'describe'/'it'/'beforeEach'` and `TS2304` for `expect`/`afterEach`, across all `*.spec.ts` and `*.e2e-spec.ts`. The tsconfig relied on automatic `@types` inclusion, which TS 6 no longer surfaces to the api program.
   → Declare them: `"types": ["node", "jest"]`.

2. **`supertest` namespace import not callable** — `TS2349` on `import * as request from 'supertest'`. It's a CommonJS `export =` module.
   → `import request = require('supertest')`. This stays callable under TS 6 and needs **no** `esModuleInterop`. A default import would require `esModuleInterop`, which (because #239 routes automerge-repo's ESM through `ts-jest`) would apply to that transpilation and crash `WebSocketServerAdapter` on `app.close()` — verified. Lint's `no-require-imports` is disabled inline with a comment explaining why.

## Scope / division of labor

The remaining TS 6 api fixes — `server!`/`repo!` definite-assignment assertions, dropping the now-unused network `@ts-expect-error`, and `baseUrl` removal — **already live on #237** and intentionally stay there: they'd break TS 5.9 (e.g. removing that directive triggers `TS2740` on 5.9, where the automerge adapter types genuinely don't line up). This PR deliberately does **not** touch `sync.gateway.ts` or `baseUrl`.

## Verification

| | TS 5.9 (current main) | TS 6.0.3 (simulated) |
|---|---|---|
| `check-types` | ✅ 0 | ✅ no jest/supertest errors |
| `lint` | ✅ 0 | — |
| `build` | ✅ 0 | — |
| `test` (unit) | ✅ 3/3 | — |
| `test:e2e` | ✅ 1/1, clean exit | — |

(The only TS 6.0.3 error left in isolation is the `baseUrl` deprecation — main's existing line, which #237 removes itself.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)