### PR TITLE
fix: drop deprecated baseUrl from all tsconfigs (TS6 prep)

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,7 +9,6 @@
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "types": ["node", "jest"],

--- a/apps/electron-client/tsconfig.json
+++ b/apps/electron-client/tsconfig.json
@@ -22,7 +22,6 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Paths */
-    "baseUrl" : ".",
     "paths": {
       "@/*": ["./src/*"],
     }

--- a/apps/web-client/tsconfig.json
+++ b/apps/web-client/tsconfig.json
@@ -20,7 +20,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "baseUrl" : ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -19,7 +19,6 @@
         "name": "next"
       }
     ],
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./app/*"],
     }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -23,7 +23,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     /* Paths */
-    "baseUrl" : ".",
     "paths": {
       "@/*": ["./app/*"],
     }


### PR DESCRIPTION
## Purpose

Continues prepping `main` for the **TypeScript v6** bump (#237), following #240 (jest globals + supertest). TS 6 makes `baseUrl` a hard error (`TS5101`; the option is removed entirely in TS 7), and five workspace tsconfigs still set it — so #237's `check-types` fails on them one after another (its CI stopped at `electron-client`).

## Change

Remove `baseUrl` from: `apps/api`, `apps/electron-client`, `apps/web-client`, `apps/web`, `packages/core`.

The four that pair `baseUrl` with `paths` all use **relative** mappings (`"@/*": ["./src/*"]` or `["./app/*"]`), which TS 5.0+ resolves relative to the tsconfig location **without** `baseUrl`. `apps/api` had `baseUrl` with no `paths` at all. So this is a no-op under the current TS 5.9 and clears the TS 6 error.

## Verification

- **TS 5.9 (current main):** `check-types` 9/9, `build`, `lint` all green — confirms no bare-specifier import relied on `baseUrl`.
- **TS 6.0.3 (per workspace):** `electron-client`, `core`, `web-client`, `web`, `docs`, and `api` all clean. (api's only residual TS 6 errors are the `server!`/`repo!` assertions + the now-unused network `@ts-expect-error` in `sync.gateway.ts` — already fixed on #237's branch.)

With #240 (merged) + this PR, main carries all the TS 5.9-safe TS 6 prep; #237 then needs only its own `sync.gateway.ts` fixes (already present) and a rebase to go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)