### PR TITLE
fix(core): give icon-only playback buttons accessible names

### DIFF
--- a/packages/core/app/components/AudioPlayer.tsx
+++ b/packages/core/app/components/AudioPlayer.tsx
@@ -55,12 +55,14 @@ export function AudioPlayer() {
         </div>
         <div className="flex gap-2 p-4">
           <Button
+            title={isPlaying ? 'Pause' : 'Play'}
             className="rounded-full p-2"
             onClick={() => setIsPlaying(!isPlaying)}
           >
             {isPlaying ? <MdPause /> : <MdPlayArrow />}
           </Button>
           <Button
+            title="Stop"
             className="rounded-full p-2"
             onClick={() => {
               setIsPlaying(false)

--- a/packages/core/app/views/Library.tsx
+++ b/packages/core/app/views/Library.tsx
@@ -150,6 +150,7 @@ function LibraryListItem({
               <MdOutlineMoreVert />
             </Button>
             <Button
+              title="Play recording"
               className={clsx(
                 'rounded-full bg-none p-2 opacity-0 transition-opacity ease-in group-hover:opacity-100 hover:bg-none hover:shadow-xs',
                 {

--- a/packages/core/app/views/Recorder.tsx
+++ b/packages/core/app/views/Recorder.tsx
@@ -195,7 +195,7 @@ export function Recorder() {
                 <MdEdit className="ml-2 opacity-0 transition-opacity delay-75 ease-in group-hover:opacity-100" />
               </Button>
               <Button
-                title="Save recoding"
+                title="Save recording"
                 className="rounded-full p-4 hover:text-green-500"
                 onClick={() => {
                   createRecordingDocument()


### PR DESCRIPTION
Groundwork for [TAP-48](https://linear.app/tapes/issue/TAP-48) (Playwright recording tests).

## What

Three icon-only buttons render nothing but a `react-icons` SVG with no `title`, so they have **no accessible name** — screen readers announce them as unlabelled buttons, and nothing can target them by role+name:

- `Library.tsx` — the play button on each recording row → `title="Play recording"`
- `AudioPlayer.tsx` — play/pause → `title={isPlaying ? 'Pause' : 'Play'}`, and stop → `title="Stop"`

Also fixes a typo: the Recorder's save button read `title="Save recoding"`.

## Why now

TAP-48 adds Playwright coverage of the recording flow. Without accessible names, those tests would have to reach the play button via positional/xpath sibling selectors, which break on any DOM reshuffle in the row. Fixing the markup is a real accessibility improvement rather than a test-only hook, so it lands separately and first.

`packages/ui`'s `Button` already forwards `title` to the underlying `<button>`, so this is purely additive.

## Notes

- No changeset: `packages/core` is `private: true`.
- No behaviour change — attributes only.
- Not verified locally (this worktree has no install state); relying on CI for lint / check-types / build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)