### PR TITLE
test(web-client): add Playwright e2e harness with a smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,65 @@ jobs:
 
       - name: Build
         run: yarn build
+
+  e2e:
+    name: E2E (web-client)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn --immutable
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install Chromium
+        run: yarn workspace web-client exec playwright install --with-deps chromium
+
+      # ubuntu-latest has no audio stack at all (no /dev/snd, no PulseAudio),
+      # and --use-fake-device-for-media-capture supplies fake *samples* but not
+      # a fake *device*: without this step enumerateDevices() returns no
+      # audioinput and getUserMedia throws NotFoundError. Two virtual sources
+      # so the device-switching test has something to switch between.
+      # `pulseaudio --start` must run unsudoed for Chromium to inherit the socket.
+      - name: Start PulseAudio with two virtual sources
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq pulseaudio
+          pulseaudio --check || pulseaudio --start --exit-idle-time=-1
+          sleep 2
+          for n in 1 2; do
+            pactl load-module module-null-sink sink_name=vsink$n \
+              sink_properties=device.description=VirtualSink$n
+            pactl load-module module-virtual-source source_name=vsource$n \
+              master=vsink$n.monitor \
+              source_properties=device.description=VirtualMic$n
+          done
+          sleep 1
+          pactl list short sources
+
+      - name: Run e2e
+        run: yarn turbo run e2e --filter=web-client
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: apps/web-client/playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# Playwright
+playwright-report
+test-results
+blob-report
+.playwright
+
 # Misc
 .DS_Store
 *.pem

--- a/apps/web-client/e2e/smoke.spec.ts
+++ b/apps/web-client/e2e/smoke.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('app shell', () => {
+  test('boots and renders the recorder navigation', async ({ page }) => {
+    await page.goto('/')
+
+    // App renders "Loading..." until the Automerge repo resolves, so waiting
+    // for the nav proves the repo was created without a reachable sync server.
+    await expect(page.getByRole('button', { name: 'Recorder' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Library' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Settings' })).toBeVisible()
+  })
+
+  test('renders the app rather than the download prompt at mobile width', async ({
+    page,
+  }) => {
+    await page.goto('/')
+    await expect(page.getByRole('button', { name: 'Recorder' })).toBeVisible()
+
+    // Above the `sm` breakpoint main.tsx swaps the app for DownloadPrompt.
+    // Guards the viewport requirement that every other test depends on.
+    await page.setViewportSize({ width: 1024, height: 800 })
+    await expect(page.getByRole('button', { name: 'Recorder' })).toBeHidden()
+  })
+})

--- a/apps/web-client/eslint.config.js
+++ b/apps/web-client/eslint.config.js
@@ -1,9 +1,19 @@
 import { config } from "@tapes-monorepo/eslint-config/react-internal";
+import globals from "globals";
 
 /** @type {import("eslint").Linter.Config} */
 export default [
   ...config,
   {
-    ignores: ["dist/**"],
+    // Playwright config and specs run in Node, not the browser.
+    files: ["e2e/**/*.ts", "playwright.config.ts"],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+  {
+    ignores: ["dist/**", "playwright-report/**", "test-results/**"],
   },
 ];

--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -10,8 +10,10 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint .",
-    "check-types": "tsc --noEmit",
-    "pull": "vercel env pull .env.local"
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json",
+    "pull": "vercel env pull .env.local",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@tapes-monorepo/core": "*",
@@ -20,16 +22,19 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@tapes-monorepo/eslint-config": "*",
     "@tapes-monorepo/tailwind-config": "*",
     "@tapes-monorepo/typescript-config": "*",
+    "@types/node": "^24.10.1",
     "@types/react": "^19.0.2",
     "@types/react-dom": "^19.0.2",
     "@vitejs/plugin-basic-ssl": "^2.3.0",
     "@vitejs/plugin-react": "^6.0.3",
     "eslint": "^9.17.0",
     "eslint-plugin-import": "^2.31.0",
+    "globals": "^17.0.0",
     "postcss": "^8.4.49",
     "tailwindcss": "^4.3.3",
     "typescript": "^6.0.0",

--- a/apps/web-client/playwright.config.ts
+++ b/apps/web-client/playwright.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig } from '@playwright/test'
+
+const PORT = 4173
+// `localhost`, not `127.0.0.1`: Vite's dev server binds the hostname, and the
+// webServer health check fails against the bare loopback address.
+const BASE_URL = `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  // CI provides a single pair of PulseAudio virtual sources, so parallel
+  // recordings would contend for the same capture device.
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // Recording tests capture for ~4s and then poll OPFS for the written file.
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: BASE_URL,
+    // main.tsx renders <App> inside `div.flex sm:hidden`; at >= 640px only the
+    // DownloadPrompt is visible. A plain narrow viewport rather than a device
+    // preset, so touch emulation doesn't change click behaviour.
+    viewport: { width: 390, height: 844 },
+    // AudioInputSelector reads navigator.permissions.query once on mount and
+    // never re-checks, so the grant has to be in place before the first load.
+    permissions: ['microphone'],
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        browserName: 'chromium',
+        launchOptions: {
+          args: [
+            // Supplies the capture *samples*. Note it does NOT supply a capture
+            // *device* on Linux: CI additionally loads PulseAudio virtual
+            // sources, without which enumerateDevices() returns no audioinput
+            // and getUserMedia throws NotFoundError.
+            '--use-fake-device-for-media-capture',
+            '--use-fake-ui-for-media-stream',
+            '--autoplay-policy=no-user-gesture-required',
+          ],
+        },
+      },
+    },
+  ],
+  webServer: {
+    // The dev server, deliberately, not `vite preview`: React StrictMode does
+    // not double-invoke in a production build, so the "exactly one
+    // MediaRecorder" test would be a tautology against a built bundle.
+    command: `yarn vite --port ${PORT} --strictPort`,
+    url: BASE_URL,
+    // main.tsx throws without this. The app never contacts it: a fresh browser
+    // profile has no stored automergeUrl, so App takes repo.create() rather
+    // than repo.find(), which is what would need a reachable server.
+    env: { VITE_SYNC_SERVER_URL: 'ws://127.0.0.1:9999' },
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+})

--- a/apps/web-client/tsconfig.e2e.json
+++ b/apps/web-client/tsconfig.e2e.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tapes-monorepo/typescript-config/base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    // DOM is required because page.evaluate/addInitScript bodies are
+    // type-checked against browser APIs.
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node"],
+    "noEmit": true,
+    "strict": true
+  },
+  "include": ["e2e", "playwright.config.ts"]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -14,6 +14,12 @@
     "check-types": {
       "dependsOn": ["^build"]
     },
+    "e2e": {
+      "dependsOn": ["^build"],
+      "cache": false,
+      "env": ["CI"],
+      "passThroughEnv": ["PLAYWRIGHT_BROWSERS_PATH", "PULSE_SERVER", "XDG_RUNTIME_DIR"]
+    },
     "dev": {
       "cache": false,
       "persistent": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -3734,6 +3734,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.61.1":
+  version: 1.61.1
+  resolution: "@playwright/test@npm:1.61.1"
+  dependencies:
+    playwright: "npm:1.61.1"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/45004139eaa7c7ec8129e4ed77a9d734aa09ed40b69162b871e4123f1d70217b7b73651431a9343ed5090d5fed11c6df1bff2a56ff4b87dc7b0371b5da87cf9c
+  languageName: node
+  linkType: hard
+
 "@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.29
   resolution: "@polka/url@npm:1.0.0-next.29"
@@ -5009,7 +5020,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^24.0.0, @types/node@npm:^24.9.0":
+"@types/node@npm:^24.0.0, @types/node@npm:^24.10.1, @types/node@npm:^24.9.0":
   version: 24.13.3
   resolution: "@types/node@npm:24.13.3"
   dependencies:
@@ -9485,12 +9496,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:^2.3.3, fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -13291,6 +13321,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright-core@npm:1.61.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/c28896ba82a602182e240ed4f9c467fb0dd9cb57d510f8aba9f25183fe1cde3a0105725a29baffa4157fe885bbb11e228032a2aad0424111584fde45303f07bd
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright@npm:1.61.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.61.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/cea1bc4d2a64ec3ef683891606774029da7b8a8036ed98332565cec2f8e89549ca1fab9a89fbfba4e08e27e0d7e7d148031e965af66d5ff97bb3c34058cfcad0
+  languageName: node
+  linkType: hard
+
 "plist@npm:^3.0.0, plist@npm:^3.0.5, plist@npm:^3.1.0":
   version: 3.1.1
   resolution: "plist@npm:3.1.1"
@@ -16551,17 +16605,20 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "web-client@workspace:apps/web-client"
   dependencies:
+    "@playwright/test": "npm:^1.61.1"
     "@tailwindcss/postcss": "npm:^4.3.3"
     "@tapes-monorepo/core": "npm:*"
     "@tapes-monorepo/eslint-config": "npm:*"
     "@tapes-monorepo/tailwind-config": "npm:*"
     "@tapes-monorepo/typescript-config": "npm:*"
+    "@types/node": "npm:^24.10.1"
     "@types/react": "npm:^19.0.2"
     "@types/react-dom": "npm:^19.0.2"
     "@vitejs/plugin-basic-ssl": "npm:^2.3.0"
     "@vitejs/plugin-react": "npm:^6.0.3"
     eslint: "npm:^9.17.0"
     eslint-plugin-import: "npm:^2.31.0"
+    globals: "npm:^17.0.0"
     postcss: "npm:^8.4.49"
     qrcode.react: "npm:^4.2.0"
     react: "npm:^19.0.0"


### PR DESCRIPTION
Part of [TAP-48](https://linear.app/tapes/issue/TAP-48). Follows #244 (accessible names).

Lands **plumbing only** — config, wiring, CI job, and a smoke test that the app boots — so the infrastructure can be proven green before the recording tests are layered on. This is the first browser-based test in the repo.

## Key design decisions

**Runs against the Vite dev server, not `vite preview`.** React StrictMode does not double-invoke in a production build, so the planned "exactly one MediaRecorder" test (T3) would be a silent tautology against a built bundle. Using dev also means `VITE_SYNC_SERVER_URL` is supplied at runtime via `webServer.env` rather than baked in at build time — so a dummy sync URL can never land in the turbo-cached `dist/`.

**The dummy sync URL is never contacted.** `main.tsx` throws without `VITE_SYNC_SERVER_URL`, but a fresh browser profile has no stored `automergeUrl`, so `App` takes `repo.create()` rather than `repo.find()` — the latter would hang forever with no reachable server. Every test therefore uses a fresh context (no `storageState`), which also isolates OPFS/IndexedDB for later file assertions.

**Viewport is 390×844.** `main.tsx` renders `<App>` inside `div.flex sm:hidden`; at ≥640px only the `DownloadPrompt` is visible. One of the two smoke tests guards this explicitly, since every future test depends on it.

## Tooling integration

- **Typecheck**: `apps/web-client/tsconfig.json` includes only `src`, so e2e files were invisible to `tsc`. Added `tsconfig.e2e.json` and chained it into `check-types` rather than widening the main config, which would couple `build`'s `tsc &&` step to Playwright types.
- **Lint**: `eslint .` already picks up the new files, but the config supplies browser globals only, so `process.env` tripped `no-undef`. Added a scoped `languageOptions.globals` block following the `apps/api` precedent — **globals only, no severity overrides** (those stay in `packages/eslint-config/base.js`).
- **Turbo**: new `e2e` task with `dependsOn: ["^build"]` (builds `@tapes-monorepo/core`, which `vite.config.ts` aliases into the bundle) and `cache: false`, since results depend on host audio state.

## CI

New **advisory** `e2e` job — deliberately not a required check until it's proven stable, matching how the lint gate was rolled in. "Build & Lint" remains the only required check.

The PulseAudio step is load-bearing, and non-obvious: `ubuntu-latest` has no audio stack at all (no `/dev/snd`, no PulseAudio, and `snd-dummy` is unavailable on the Azure kernel), and `--use-fake-device-for-media-capture` supplies fake *samples* but **not** a fake *device*. Without it, `enumerateDevices()` returns zero audio inputs and `getUserMedia` throws `NotFoundError`. Two virtual sources are loaded so the later device-switching test has something to switch between. This was established empirically — see the spike results on the Linear issue.

## Verification

- `yarn lint`, `yarn check-types`, `yarn build` all pass locally (check-types now covers the e2e project).
- `yarn e2e` passes locally on macOS: 2/2.
- The CI e2e job on this PR is the real test of the PulseAudio setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)