### PR TITLE
test(web-client): cover the recording flow and StrictMode recorder count

### DIFF
--- a/apps/web-client/e2e/fixtures.ts
+++ b/apps/web-client/e2e/fixtures.ts
@@ -1,0 +1,212 @@
+import { test as base, expect, type Page } from '@playwright/test'
+import type { E2EState, RecorderConstruction } from './globals'
+
+/**
+ * Installed before any app code runs. Wraps the browser APIs the recording
+ * path uses so tests can assert on what the app actually asked for, rather
+ * than only on what ended up on screen.
+ */
+const installInstrumentation = () => {
+  const state: E2EState = {
+    mediaRecorderCount: 0,
+    constructions: [],
+    gumConstraints: [],
+    workerMessageListenerAdds: 0,
+    workerMessageListenerRemoves: 0,
+  }
+  window.__tapesE2E = state
+
+  const realGetUserMedia = navigator.mediaDevices.getUserMedia.bind(
+    navigator.mediaDevices,
+  )
+  navigator.mediaDevices.getUserMedia = (
+    constraints?: MediaStreamConstraints,
+  ) => {
+    if (constraints) {
+      state.gumConstraints.push(constraints)
+    }
+    return realGetUserMedia(constraints)
+  }
+
+  // Subclass rather than proxy: RecordingContext calls the *static*
+  // MediaRecorder.isTypeSupported before constructing, and `extends` inherits
+  // statics for free.
+  const RealMediaRecorder = window.MediaRecorder
+  class CountingMediaRecorder extends RealMediaRecorder {
+    constructor(stream: MediaStream, options?: MediaRecorderOptions) {
+      super(stream, options)
+      const track = stream.getAudioTracks()[0]
+      state.mediaRecorderCount += 1
+      state.constructions.push({
+        trackDeviceId: track?.getSettings().deviceId,
+        trackLabel: track?.label ?? '',
+      })
+    }
+  }
+  window.MediaRecorder = CountingMediaRecorder as typeof MediaRecorder
+
+  // Message-listener churn on the recording worker. Under dev StrictMode the
+  // effect in RecordingContext mounts, unmounts and remounts, so a correct
+  // implementation adds two listeners and removes one.
+  const realAdd = Worker.prototype.addEventListener
+  const realRemove = Worker.prototype.removeEventListener
+  Worker.prototype.addEventListener = function (
+    this: Worker,
+    ...args: Parameters<Worker['addEventListener']>
+  ) {
+    if (args[0] === 'message') {
+      state.workerMessageListenerAdds += 1
+    }
+    return realAdd.apply(this, args)
+  }
+  Worker.prototype.removeEventListener = function (
+    this: Worker,
+    ...args: Parameters<Worker['removeEventListener']>
+  ) {
+    if (args[0] === 'message') {
+      state.workerMessageListenerRemoves += 1
+    }
+    return realRemove.apply(this, args)
+  }
+}
+
+export const test = base.extend({
+  // Note the parameter is named `provide`, not Playwright's usual `use`:
+  // a bare `use(...)` call reads as a React hook to eslint-plugin-react-hooks.
+  page: async ({ page }, provide) => {
+    await page.addInitScript(installInstrumentation)
+    await provide(page)
+  },
+})
+
+export { expect }
+
+export const readState = (page: Page): Promise<E2EState> =>
+  page.evaluate(() => window.__tapesE2E)
+
+/** Navigates to the app and waits for the Automerge repo to resolve. */
+export const openApp = async (page: Page) => {
+  await page.goto('/')
+  // App renders "Loading..." until the repo exists, so the nav is the signal.
+  await expect(page.getByRole('button', { name: 'Recorder' })).toBeVisible()
+}
+
+/** Device ids offered by AudioInputSelector, minus its placeholder option. */
+export const deviceOptionValues = async (page: Page) => {
+  const select = page.getByRole('combobox').first()
+
+  // AudioInputSelector renders an "Allow access" button until its permission
+  // query resolves, then swaps in the <select>. Don't probe for that button
+  // and click it — it is often already gone by the time the click lands
+  // (Playwright then waits forever on a detached element). Wait for the
+  // outcome instead, and only take the explicit path if it never arrives.
+  try {
+    await select.waitFor({ state: 'visible', timeout: 5_000 })
+  } catch {
+    await page
+      .getByRole('button', { name: 'Allow access to audio input devices' })
+      .click()
+    await select.waitFor({ state: 'visible', timeout: 10_000 })
+  }
+
+  return select
+    .locator('option')
+    .evaluateAll((options) =>
+      options
+        .map((option) => (option as HTMLOptionElement).value)
+        .filter((value) => value !== ''),
+    )
+}
+
+export const selectDevice = async (page: Page, deviceId: string) => {
+  await page.getByRole('combobox').first().selectOption(deviceId)
+}
+
+/**
+ * Records for `durationMs`. Four seconds by default: at one second Chromium
+ * intermittently emits a single zero-byte blob (measured 3/5 and 1/5 on CI
+ * runners), while 4s was clean across 12 trials.
+ */
+export const recordFor = async (page: Page, durationMs = 4000) => {
+  // getByTitle, not getByRole+name: while recording the button renders the
+  // elapsed Timer, and text content wins over `title` when the accessible name
+  // is computed — so the button is named "00:00:04:21", not "Stop recording".
+  await page.getByTitle('Start recording').click()
+  await page.waitForTimeout(durationMs)
+  await page.getByTitle('Stop recording').click()
+}
+
+/** Saves the pending recording, optionally renaming it first. */
+export const saveRecording = async (page: Page, name?: string) => {
+  if (name) {
+    // Likewise: this button's accessible name is the current recording name.
+    await page.getByTitle(/^Rename /).click()
+    const input = page.locator('#new-recording-name-input')
+    await expect(input).toBeVisible()
+    await input.fill(name)
+    // Enter commits the name and creates the Automerge document.
+    await input.press('Enter')
+    return
+  }
+  await page.getByTitle('Save recording').click()
+}
+
+export const opfsFiles = (page: Page) =>
+  page.evaluate(async () => {
+    const root = await navigator.storage.getDirectory()
+    const files: { name: string; size: number }[] = []
+    for await (const handle of root.values()) {
+      if (handle.kind !== 'file') continue
+      files.push({ name: handle.name, size: (await handle.getFile()).size })
+    }
+    return files
+  })
+
+/**
+ * The bytes land on the final `dataavailable` -> `recorder:write`, strictly
+ * after the worker has already answered `recorder:stop`, so this must poll.
+ */
+export const expectRecordedBytes = async (page: Page) => {
+  await expect
+    .poll(
+      async () => {
+        const files = await opfsFiles(page)
+        return Math.max(0, ...files.map((file) => file.size))
+      },
+      {
+        timeout: 20_000,
+        message: 'no OPFS file ever reached a non-zero size',
+      },
+    )
+    .toBeGreaterThan(0)
+}
+
+/**
+ * Decodes the recorded bytes in-page. This is the honest "is it playable?"
+ * check: AudioPlayerContext keeps its HTMLAudioElement in a ref and never
+ * mounts it, so there is no <audio> element in the DOM to inspect.
+ */
+export const decodeLargestRecording = (page: Page) =>
+  page.evaluate(async () => {
+    const root = await navigator.storage.getDirectory()
+    let best: ArrayBuffer | null = null
+    for await (const handle of root.values()) {
+      if (handle.kind !== 'file') continue
+      const buffer = await (await handle.getFile()).arrayBuffer()
+      if (!best || buffer.byteLength > best.byteLength) best = buffer
+    }
+    if (!best) return null
+    const audioContext = new AudioContext()
+    try {
+      const decoded = await audioContext.decodeAudioData(best)
+      return {
+        duration: decoded.duration,
+        sampleRate: decoded.sampleRate,
+        channels: decoded.numberOfChannels,
+      }
+    } finally {
+      await audioContext.close()
+    }
+  })
+
+export type { E2EState, RecorderConstruction }

--- a/apps/web-client/e2e/globals.d.ts
+++ b/apps/web-client/e2e/globals.d.ts
@@ -1,0 +1,23 @@
+export {}
+
+export type RecorderConstruction = {
+  trackDeviceId: string | undefined
+  trackLabel: string
+}
+
+export type E2EState = {
+  mediaRecorderCount: number
+  constructions: RecorderConstruction[]
+  gumConstraints: MediaStreamConstraints[]
+  workerMessageListenerAdds: number
+  workerMessageListenerRemoves: number
+}
+
+declare global {
+  interface Window {
+    __tapesE2E: E2EState
+    // Set by @vitejs/plugin-react's refresh preamble, which only runs on the
+    // dev server. Used to prove StrictMode is actually active.
+    __vite_plugin_react_preamble_installed__?: boolean
+  }
+}

--- a/apps/web-client/e2e/recording.spec.ts
+++ b/apps/web-client/e2e/recording.spec.ts
@@ -1,0 +1,37 @@
+import {
+  test,
+  expect,
+  openApp,
+  deviceOptionValues,
+  selectDevice,
+  recordFor,
+  saveRecording,
+  expectRecordedBytes,
+  decodeLargestRecording,
+} from './fixtures'
+
+test.describe('recording', () => {
+  test('produces a decodable file and lists it in the library', async ({
+    page,
+  }) => {
+    await openApp(page)
+
+    const devices = await deviceOptionValues(page)
+    expect(devices.length).toBeGreaterThan(0)
+    await selectDevice(page, devices[0])
+
+    await recordFor(page)
+    await saveRecording(page, 'E2E take one')
+
+    await expectRecordedBytes(page)
+
+    // Proves the container and codec are real, not just that bytes exist.
+    const decoded = await decodeLargestRecording(page)
+    expect(decoded).not.toBeNull()
+    expect(decoded?.duration).toBeGreaterThan(1)
+    expect(decoded?.sampleRate).toBeGreaterThan(0)
+
+    await page.getByRole('button', { name: 'Library' }).click()
+    await expect(page.getByText('E2E take one')).toBeVisible()
+  })
+})

--- a/apps/web-client/e2e/strict-mode.spec.ts
+++ b/apps/web-client/e2e/strict-mode.spec.ts
@@ -1,0 +1,52 @@
+import {
+  test,
+  expect,
+  openApp,
+  deviceOptionValues,
+  selectDevice,
+  recordFor,
+  expectRecordedBytes,
+  readState,
+} from './fixtures'
+
+test.describe('StrictMode', () => {
+  test('constructs exactly one MediaRecorder per recording', async ({
+    page,
+  }) => {
+    await openApp(page)
+
+    // Guard, not decoration: StrictMode does not double-invoke in a production
+    // build, so this whole test silently becomes a tautology if the harness is
+    // ever pointed at `vite preview`. Fail loudly instead.
+    const isDevServer = await page.evaluate(
+      () =>
+        Boolean(window.__vite_plugin_react_preamble_installed__) ||
+        Boolean(document.querySelector('script[src*="@vite/client"]')),
+    )
+    expect(
+      isDevServer,
+      'expected the dev server, where StrictMode double-invokes effects',
+    ).toBe(true)
+
+    const devices = await deviceOptionValues(page)
+    expect(devices.length).toBeGreaterThan(0)
+    await selectDevice(page, devices[0])
+
+    await recordFor(page)
+    await expectRecordedBytes(page)
+
+    const state = await readState(page)
+
+    // The double-invoke really happened: RecordingContext's effect mounted
+    // more than once. Without this, "one recorder" proves nothing.
+    expect(state.workerMessageListenerAdds).toBeGreaterThan(1)
+    // ...and its cleanup ran, leaving exactly one live listener.
+    expect(
+      state.workerMessageListenerAdds - state.workerMessageListenerRemoves,
+    ).toBe(1)
+
+    // The actual regression: a leaked duplicate listener would start a second
+    // recorder on the same `recorder:start:response`.
+    expect(state.mediaRecorderCount).toBe(1)
+  })
+})


### PR DESCRIPTION
Part of [TAP-48](https://linear.app/tapes/issue/TAP-48). Builds on #244 and #245. This is PR C — T1 and T3; the device-switch test (T2) follows.

## T1 — recording produces a decodable file

Records for 4s, saves, polls OPFS for a non-zero file, then **decodes the bytes in-page with `decodeAudioData`** and asserts the result is longer than a second. Finally asserts the recording shows up in the Library.

Decoding is the honest "is it playable?" check. `AudioPlayerContext` keeps its `HTMLAudioElement` in a ref and never mounts it, so there is no `<audio>` element to inspect, and the player's duration text is only rendered when `isFinite` — asserting on the UI would be both indirect and flaky. Decoding proves the container and codec are real.

The 4s duration is not arbitrary: at 1s, Chromium intermittently emits a single **zero-byte** blob (measured 3/5 and 1/5 on runners), while 4s was clean across 12 trials. That unguarded zero-byte path is filed separately as TAP-53.

The poll is mandatory — bytes land on the final `dataavailable` → `recorder:write`, strictly *after* the worker has already answered `recorder:stop`.

## T3 — exactly one MediaRecorder per recording

Instruments `MediaRecorder` construction and message-listener churn on the worker.

The assertion order matters. It first asserts the **StrictMode double-invoke actually happened** (more than one listener added), then that cleanup left exactly one live listener, and only then that exactly one recorder was constructed. Without that first check, "one recorder" would pass just as happily in an app where the effect never double-mounted — a test that cannot fail. It also fails loudly if ever pointed at a non-dev server, where StrictMode does not double-invoke.

## Both tests were verified to fail

Per the plan, I broke each behaviour and confirmed the test catches it:

| Break | Result |
|---|---|
| Remove `worker.removeEventListener` cleanup in `RecordingContext` | T3 fails — 3 live listeners instead of 1 |
| Skip the write in the worker's `recorder:write` | T1 fails — "no OPFS file ever reached a non-zero size" |

Both were reverted; the diff touches no application code.

## Two selector traps, both found by running the tests rather than reading the markup

1. **The record button renders the elapsed Timer while recording**, and text content beats `title` when computing an accessible name — so mid-recording the button is named `"00:00:04:21"`, not `"Stop recording"`. `getByRole('button', { name: 'Stop recording' })` waits forever. Same trap on the rename button, whose accessible name is the recording name. Both now use `getByTitle`.
2. **`AudioInputSelector` briefly renders an "Allow access" button** before its permission query resolves and swaps in the device `<select>`. Probing for that button and clicking it races the re-render and hangs on a detached element. The helper now waits for the outcome and only takes the explicit path if the select never appears.

## Verification

- `yarn e2e`: 4/4 passing locally on macOS (~13s).
- `lint` and `check-types` green.
- Note: run via `turbo run e2e`, not `yarn workspace web-client e2e` — the dev server resolves `@tapes-monorepo/core` to `packages/core/dist`, so without turbo's `^build` you silently test a stale bundle. This bit me during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)