### PR TITLE
fix(core): actually use the selected audio input device

### DIFF
--- a/apps/web-client/e2e/device-switch.spec.ts
+++ b/apps/web-client/e2e/device-switch.spec.ts
@@ -1,0 +1,48 @@
+import {
+  test,
+  expect,
+  openApp,
+  deviceOptionValues,
+  selectDevice,
+  recordFor,
+  saveRecording,
+  readState,
+} from './fixtures'
+
+test.describe('input device selection', () => {
+  test('records from the newly selected device', async ({ page }) => {
+    await openApp(page)
+
+    const devices = await deviceOptionValues(page)
+    // CI provides two PulseAudio virtual sources; a laptop with a single mic
+    // should skip rather than fail.
+    test.skip(devices.length < 2, 'needs at least two audio input devices')
+    const [deviceA, deviceB] = devices
+
+    await selectDevice(page, deviceA)
+    await recordFor(page)
+    await saveRecording(page, 'take A')
+
+    // Once a device is chosen the Recorder swaps its selector for the record
+    // controls, so Settings is the only in-app way to change it.
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await selectDevice(page, deviceB)
+    await page.getByRole('button', { name: 'Recorder' }).click()
+
+    await recordFor(page)
+    await saveRecording(page, 'take B')
+
+    const { constructions } = await readState(page)
+    expect(constructions).toHaveLength(2)
+
+    // The regression test for TAP-54: the app used to request the device with
+    // a bare (ideal) `deviceId`, which Chromium ignores, so both recordings
+    // came from the system default. These assert the track really is the
+    // device that was asked for.
+    expect(constructions[0].trackDeviceId).toBe(deviceA)
+    expect(constructions[1].trackDeviceId).toBe(deviceB)
+    expect(constructions[1].trackDeviceId).not.toBe(
+      constructions[0].trackDeviceId,
+    )
+  })
+})

--- a/apps/web-client/e2e/fixtures.ts
+++ b/apps/web-client/e2e/fixtures.ts
@@ -119,7 +119,14 @@ export const deviceOptionValues = async (page: Page) => {
 }
 
 export const selectDevice = async (page: Page, deviceId: string) => {
-  await page.getByRole('combobox').first().selectOption(deviceId)
+  // Target the select that actually offers this device rather than a
+  // positional one. The Settings view has three comboboxes (input device,
+  // recording format, channels) and the device selector populates last —
+  // it waits on a permissions query and enumerateDevices — so `.first()`
+  // races it and lands on the format select on a slow machine.
+  const select = page.locator(`select:has(option[value="${deviceId}"])`)
+  await expect(select).toBeVisible()
+  await select.selectOption(deviceId)
 }
 
 /**

--- a/packages/core/app/context/RecordingContext.tsx
+++ b/packages/core/app/context/RecordingContext.tsx
@@ -87,7 +87,16 @@ export const RecordingStateProvider = ({
       switch (type) {
         case 'recorder:start:response': {
           setHandleFilename(payload.filename)
-          const audioStream = await getAudioStream(audioInputDeviceId ?? '')
+          let audioStream: MediaStream
+          try {
+            audioStream = await getAudioStream(audioInputDeviceId ?? '')
+          } catch (error) {
+            // Otherwise this rejects inside an event listener and the UI stays
+            // in the recording state with no recorder behind it.
+            console.error('Failed to open the audio input:', error)
+            setIsRecording(false)
+            break
+          }
           const recorder = await getMediaRecorder(audioStream)
           // Attach the listener at construction, before start(), so the first
           // (and only, without a timeslice) `dataavailable` is never missed.

--- a/packages/core/app/utils.ts
+++ b/packages/core/app/utils.ts
@@ -1,15 +1,40 @@
+/** The selected input device exists in settings but is no longer available. */
+export class AudioInputUnavailableError extends Error {
+  constructor(deviceId: string) {
+    super(`Selected audio input device is unavailable: ${deviceId}`)
+    this.name = 'AudioInputUnavailableError'
+  }
+}
+
+const isOverconstrained = (error: unknown) =>
+  typeof error === 'object' &&
+  error !== null &&
+  'name' in error &&
+  (error as { name: unknown }).name === 'OverconstrainedError'
+
 export const getAudioStream = async (selectedMediaDeviceId: string) => {
-  let audioStream
   try {
-    audioStream = await navigator.mediaDevices.getUserMedia({
-      audio: { deviceId: selectedMediaDeviceId },
+    return await navigator.mediaDevices.getUserMedia({
+      // `exact` matters: a bare `deviceId` is only an *ideal* hint, and
+      // Chromium ignores it — it hands back the system default microphone no
+      // matter which device was selected, so the app silently recorded from
+      // the wrong input. Fall back to `true` (the default device) when no
+      // device has been chosen yet, rather than sending an empty constraint.
+      audio: selectedMediaDeviceId
+        ? { deviceId: { exact: selectedMediaDeviceId } }
+        : true,
       video: false,
     })
   } catch (error) {
     console.error(error)
+    // With `exact`, a stored-but-missing device now rejects instead of quietly
+    // falling back. Surface that as its own error so callers can prompt for a
+    // different input rather than reporting a generic failure.
+    if (isOverconstrained(error)) {
+      throw new AudioInputUnavailableError(selectedMediaDeviceId)
+    }
     throw new Error('Could not get media stream')
   }
-  return audioStream
 }
 
 export function setAutomergeUrl(url: string) {

--- a/packages/core/app/views/Recorder.tsx
+++ b/packages/core/app/views/Recorder.tsx
@@ -394,7 +394,10 @@ function useMonitor(selectedMediaDeviceId: string | undefined) {
     }
 
     if (isMonitoring) {
-      monitor()
+      monitor().catch((error) => {
+        console.error('Could not monitor the selected input:', error)
+        setIsMonitoring(false)
+      })
     }
 
     return () => {


### PR DESCRIPTION
Fixes [TAP-54](https://linear.app/tapes/issue/TAP-54) and completes [TAP-48](https://linear.app/tapes/issue/TAP-48) (this is T2, the last of the three tests).

## The bug

`getAudioStream` requested the chosen microphone with a bare `deviceId`, which per spec is only an **ideal** constraint. Chromium ignores it and hands back the system default — so selecting a different input changed the setting and the UI, but **not the audio being captured**. A user with an audio interface selected was recording from their laptop's built-in mic, with nothing indicating anything was wrong.

Measured on macOS against two real devices, requesting each one both ways:

```
ideal  asked="C (2)-mikrofon"                 -> got="MacBook Pro-mikrofon (Built-in)"  honoured=false
exact  asked="C (2)-mikrofon"                 -> got="C (2)-mikrofon"                   honoured=true
ideal  asked="MacBook Pro-mikrofon (Built-in)" -> got="MacBook Pro-mikrofon (Built-in)"  honoured=false
exact  asked="MacBook Pro-mikrofon (Built-in)" -> got="MacBook Pro-mikrofon (Built-in)"  honoured=true
```

With `ideal`, `getSettings().deviceId` is `"default"` in both cases. **This reproduces with `--use-fake-device-for-media-capture` removed**, against real hardware — it is real behaviour, not a test artifact.

Distinct from the stale-closure bug fixed under GH #218: that stopped the selected id from *updating*; this meant the id never had any *effect*.

## The knock-on work

`exact` rejects with `OverconstrainedError` where the old code silently fell back, so the failure paths that were previously unreachable now matter:

- `getAudioStream` distinguishes that case as `AudioInputUnavailableError`, so callers can prompt for a different input rather than report a generic failure.
- `RecordingContext` catches it and leaves the recording state. Previously this would reject *inside an event listener*, stranding the UI mid-recording with no recorder behind it.
- `useMonitor` turns monitoring back off instead of leaking an unhandled rejection. `AudioVisualizer` already had a `.catch`.
- An empty selection now requests `audio: true` rather than sending an empty constraint.

## T2 — the regression test

Records on one device, switches via Settings (the only in-app switcher once a device is chosen — the Recorder swaps its selector for the record controls), records on another, and asserts each track really *is* the device requested.

**Verified it fails without the fix**, reporting the exact symptom:

```
Expected: "e0eea0474e679e58b5e6518f448c298d9cfeb3448844496e99818e1cb1147042"
Received: "default"
```

It skips when fewer than two input devices are present, so a single-mic laptop doesn't fail the suite.

## Verification

- `yarn e2e`: 5/5 locally on macOS.
- `lint` and `check-types` green for both `core` and `web-client`.
- The `exact` constraint is honoured even under `--use-fake-device-for-media-capture`, so T2 is meaningful in CI too — though CI uses PulseAudio virtual sources, and that's what this PR's CI run confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)