### PR TITLE
fix(api): keep tsc incremental cache inside dist so builds can't go stale

### DIFF
--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -1,7 +1,11 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // Keep the incremental cache inside outDir so nest's deleteOutDir clears
+    // both together. Left outside, a surviving cache makes tsc think the build
+    // is up to date and emit nothing, leaving no dist/main for `nest start`.
+    "tsBuildInfoFile": "./dist/tsconfig.build.tsbuildinfo"
   },
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
 }


### PR DESCRIPTION
## Problem

`yarn dev` in `apps/api` failed with a module not found error — nest was looking for `apps/api/dist/main`, but no `dist/` directory existed. `yarn build` also silently produced nothing, exiting successfully with no output.

## Root cause

`nest-cli.json` sets `deleteOutDir: true`, so every build wipes `dist/`. But `tsconfig.build.json` left the incremental cache at the package root (`apps/api/tsconfig.build.tsbuildinfo`), where the wipe didn't reach.

Once those two drifted apart — cache present, `dist/` gone — tsc read the surviving cache, concluded every file was already up to date, and emitted nothing. `nest start` then had no `dist/main` to load. The build reported success the whole time, which is what made this confusing to diagnose.

## Fix

Point `tsBuildInfoFile` at `./dist/tsconfig.build.tsbuildinfo`. The cache now lives inside the directory `deleteOutDir` clears, so the cache and the output it describes are deleted together and cannot desync.

## Verification

- `yarn build` twice in a row: both emit `dist/main.js`; cache lands in `dist/`; no stray file at the package root
- `yarn check-types` — passes
- `yarn lint` — passes
- `node dist/main` — Nest boots, routes map, SyncGateway initializes and accepts client connections

Note: recovering an already-broken checkout needs a one-time `rm -f apps/api/tsconfig.build.tsbuildinfo` (already done in the local working copy). After this change it can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)