### PR TITLE
fix(electron-client): finalize the WAV header so durations aren't bogus

### DIFF
--- a/apps/electron-client/src/channels/CreateRecordingChannel.ts
+++ b/apps/electron-client/src/channels/CreateRecordingChannel.ts
@@ -84,7 +84,15 @@ export class CreateRecordingChannel implements IpcChannel {
     }
 
     try {
-      this.sox.kill('SIGQUIT')
+      // SIGINT (not SIGQUIT) — sox only seeks back to patch the WAV header
+      // with the real data-chunk size when it shuts down cleanly. Killed with
+      // SIGQUIT it leaves the 0x7FFFF800 placeholder in place, and every
+      // recording then reports the same bogus multi-hour duration to players.
+      const sox = this.sox
+      await new Promise<void>((resolve) => {
+        sox.once('close', () => resolve())
+        sox.kill('SIGINT')
+      })
     } catch (error) {
       console.error(error)
       event.sender.send(request.responseChannel, {

--- a/packages/core/app/components/FormattedTime.tsx
+++ b/packages/core/app/components/FormattedTime.tsx
@@ -1,8 +1,11 @@
 export function FormattedTime({ time }: { time: number }) {
-  // const centiseconds = ('0' + (Math.floor(time / 10) % 100)).slice(-2)
-  const seconds = ('0' + (Math.floor(time / 1000) % 60)).slice(-2)
-  const minutes = ('0' + (Math.floor(time / 60000) % 60)).slice(-2)
-  const hours = ('0' + Math.floor(time / 3600000)).slice(-2)
+  // Non-finite or negative input would otherwise render as `aN:aN:aN`.
+  const ms = Number.isFinite(time) && time > 0 ? time : 0
+
+  // const centiseconds = ('0' + (Math.floor(ms / 10) % 100)).slice(-2)
+  const seconds = ('0' + (Math.floor(ms / 1000) % 60)).slice(-2)
+  const minutes = ('0' + (Math.floor(ms / 60000) % 60)).slice(-2)
+  const hours = ('0' + Math.floor(ms / 3600000)).slice(-2)
 
   return `${hours}:${minutes}:${seconds}`
 }

--- a/packages/core/app/context/AudioPlayerContext.tsx
+++ b/packages/core/app/context/AudioPlayerContext.tsx
@@ -90,10 +90,8 @@ export const AudioPlayerProvider = ({
     audio.load()
 
     const onLoadedMetadata = () => {
-      const scaledDuration =
-        audio.duration / (appContext.type === 'electron-client' ? 1000 : 1)
-      durationRef.current = scaledDuration
-      setDuration(scaledDuration)
+      durationRef.current = audio.duration
+      setDuration(audio.duration)
     }
 
     const onCanPlay = async () => {
@@ -130,7 +128,7 @@ export const AudioPlayerProvider = ({
       audio.removeEventListener('ended', onEnded)
       audio.removeEventListener('error', onError)
     }
-  }, [isPlaying, appContext.type])
+  }, [isPlaying])
 
   return (
     <AudioPlayerContext.Provider


### PR DESCRIPTION
The duration in `AudioPlayer` always rendered as `00:00:12`.

## Root cause

Not `FormattedTime` — its arithmetic is correct, and both call sites pass milliseconds consistently. The `duration` value itself was a constant.

`CreateRecordingChannel.onRecorderStop` killed sox with **SIGQUIT**. sox writes a placeholder data-chunk size into the WAV header up front and only seeks back to patch it with the real size on a clean shutdown. SIGQUIT never gives it that chance, so every recording shipped the placeholder `0x7FFFF800` and players derived the same duration from it no matter how long the take was:

- 44.1 kHz **stereo**: 2147479552 / 176400 ≈ **12174 s**
- 44.1 kHz mono: 2147479552 / 88200 ≈ 24348 s

Verified against the bundled `sox-14.4.2-macOS`, killing it mid-stream on a rate-limited input:

| signal | real audio | `data` size field | player sees |
| --- | --- | --- | --- |
| SIGQUIT | 1.86 s | 2147479552 | 24347.8 s ❌ |
| SIGINT | 1.86 s | 163840 | 1.9 s ✅ |
| SIGTERM | 1.86 s | 163840 | 1.9 s ✅ |

The `audio.duration / (electron-client ? 1000 : 1)` line in `AudioPlayerContext` was compensating for exactly that constant — 12174 / 1000 → `00:00:12`. It is why the number looked plausible instead of obviously broken, and why the web client (real durations, no scaling) was unaffected.

## Changes

- Kill sox with `SIGINT` and await `close` before reporting the file ready, so the header is finalized and the file complete before the renderer reads it.
- Drop the `/ 1000` scaling — `HTMLMediaElement.duration` is always seconds on both platforms.
- `FormattedTime`: clamp non-finite/negative input, which rendered as `aN:aN:aN`.

## Note

Recordings already on disk still have unfinalized headers; this fixes new ones. They will keep misreporting duration (and seeking) in any player, so a repair pass over the existing library may be worth a follow-up.

## Testing

`turbo build lint check-types` green for `@tapes-monorepo/core` and `electron-client`. **Not yet verified by making an actual recording in the electron client** — worth a manual take before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)