### PR TITLE
feat(electron-client): embed the Automerge sync server in the main process

### DIFF
--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^24.0.0",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.1",
+    "@types/ws": "^8.5.13",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitejs/plugin-react": "^6.0.3",
@@ -74,6 +75,10 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@automerge/automerge": "^3.0.0",
+    "@automerge/automerge-repo": "^2.0.0",
+    "@automerge/automerge-repo-network-websocket": "^2.0.0",
+    "@automerge/automerge-repo-storage-nodefs": "^2.0.0",
     "@dotenvx/dotenvx": "^2.0.0",
     "@tapes-monorepo/core": "*",
     "clsx": "^2.1.1",
@@ -81,6 +86,7 @@
     "node-stream-zip": "^1.15.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "update-electron-app": "^3.1.0"
+    "update-electron-app": "^3.1.0",
+    "ws": "^8.18.0"
   }
 }

--- a/apps/electron-client/src/channels/GetSyncServerInfoChannel.ts
+++ b/apps/electron-client/src/channels/GetSyncServerInfoChannel.ts
@@ -1,0 +1,14 @@
+import { IpcMainEvent } from 'electron'
+import { IpcChannel, IpcRequest } from '@/types'
+import { getSyncServerInfo } from '@/syncServer'
+
+export class GetSyncServerInfoChannel implements IpcChannel {
+  name = 'sync:get-server-info'
+  handle(event: IpcMainEvent, request: IpcRequest) {
+    const { responseChannel } = request
+    if (!responseChannel) {
+      return
+    }
+    event.sender.send(responseChannel, getSyncServerInfo())
+  }
+}

--- a/apps/electron-client/src/channels/SetSyncServerLanChannel.ts
+++ b/apps/electron-client/src/channels/SetSyncServerLanChannel.ts
@@ -1,0 +1,36 @@
+import { IpcMainEvent } from 'electron'
+import { IpcChannel, IpcRequest } from '@/types'
+import { startSyncServer, stopSyncServer } from '@/syncServer'
+import {
+  readSyncServerConfig,
+  syncStoragePath,
+  writeSyncServerConfig,
+} from '@/syncServerConfig'
+
+export class SetSyncServerLanChannel implements IpcChannel {
+  name = 'sync:set-lan-enabled'
+  async handle(event: IpcMainEvent, request: IpcRequest) {
+    const { responseChannel } = request
+    if (!responseChannel) {
+      return
+    }
+
+    try {
+      const { enabled } = request.data as { enabled: boolean }
+      const config = { ...readSyncServerConfig(), lanEnabled: enabled }
+      writeSyncServerConfig(config)
+
+      await stopSyncServer()
+      const info = await startSyncServer({
+        storagePath: syncStoragePath(),
+        host: enabled ? '0.0.0.0' : '127.0.0.1',
+        peerId: config.peerId,
+      })
+
+      event.sender.send(responseChannel, info)
+    } catch (error) {
+      console.error('Failed to switch sync server binding:', error)
+      event.sender.send(responseChannel, undefined)
+    }
+  }
+}

--- a/apps/electron-client/src/index.ts
+++ b/apps/electron-client/src/index.ts
@@ -1,8 +1,10 @@
 import { CreateRecordingChannel } from './channels/CreateRecordingChannel'
 import { DeleteRecordingChannel } from './channels/DeleteRecordingChannel'
 import { EditRecordingChannel } from './channels/EditRecordingChannel'
+import { GetSyncServerInfoChannel } from './channels/GetSyncServerInfoChannel'
 import { OpenDirectoryDialogChannel } from './channels/OpenDirectoryDialogChannel'
 import { SetDefaultAudioInputChannel } from './channels/SetDefaultAudioInputChannel'
+import { SetSyncServerLanChannel } from './channels/SetSyncServerLanChannel'
 import { MainWindow } from './main'
 
 new MainWindow().init([
@@ -11,4 +13,6 @@ new MainWindow().init([
   new EditRecordingChannel(),
   new DeleteRecordingChannel(),
   new SetDefaultAudioInputChannel(),
+  new GetSyncServerInfoChannel(),
+  new SetSyncServerLanChannel(),
 ])

--- a/apps/electron-client/src/main.ts
+++ b/apps/electron-client/src/main.ts
@@ -9,6 +9,8 @@ import installExtension, {
 import { updateElectronApp } from 'update-electron-app'
 import { IpcChannel } from './types'
 import { cacheServer } from './cacheServer'
+import { startSyncServer, stopSyncServer } from './syncServer'
+import { readSyncServerConfig, syncStoragePath } from './syncServerConfig'
 
 updateElectronApp()
 
@@ -29,11 +31,13 @@ export class MainWindow {
     // Some APIs can only be used after this event occurs.
     app.on('ready', () => {
       this.startCacheServer()
+      this.startSyncServer()
       this.registerCustomProtocols()
       this.createWindow()
     })
     app.on('window-all-closed', this.onWindowAllClosed)
     app.on('activate', this.onActivate)
+    app.on('will-quit', this.onWillQuit)
     this.registerIpcChannels(ipcChannels)
   }
 
@@ -101,6 +105,37 @@ export class MainWindow {
         channel.handle(event, request),
       ),
     )
+  }
+
+  private syncServerStopped = false
+
+  private async startSyncServer() {
+    try {
+      const config = readSyncServerConfig()
+      await startSyncServer({
+        storagePath: syncStoragePath(),
+        host: config.lanEnabled ? '0.0.0.0' : '127.0.0.1',
+        peerId: config.peerId,
+      })
+    } catch (error) {
+      console.error('Failed to start sync server:', error)
+    }
+  }
+
+  private onWillQuit = (event: Electron.Event) => {
+    // Flush the Automerge repo to disk before the process exits.
+    if (this.syncServerStopped) {
+      return
+    }
+    event.preventDefault()
+    this.syncServerStopped = true
+    stopSyncServer()
+      .catch((error) => {
+        console.error('Failed to stop sync server:', error)
+      })
+      .finally(() => {
+        app.exit(0)
+      })
   }
 
   private startCacheServer() {

--- a/apps/electron-client/src/preload.ts
+++ b/apps/electron-client/src/preload.ts
@@ -11,6 +11,8 @@ const validChannels: ValidIpcChanel[] = [
   'storage:delete-recording',
   'recorder:start',
   'recorder:stop',
+  'sync:get-server-info',
+  'sync:set-lan-enabled',
 ]
 
 const validResponseChannels = validChannels.map(

--- a/apps/electron-client/src/renderer.tsx
+++ b/apps/electron-client/src/renderer.tsx
@@ -1,6 +1,6 @@
-import { StrictMode } from 'react'
+import { StrictMode, useEffect, useState } from 'react'
 import { createRoot } from 'react-dom/client'
-import { App, IpcService } from '@tapes-monorepo/core'
+import { App, IpcService, SyncServerInfo } from '@tapes-monorepo/core'
 import './index.css'
 
 const rootElement = document.getElementById('root')
@@ -8,13 +8,55 @@ if (!rootElement) {
   throw new Error('Root element not found')
 }
 
-if (!import.meta.env.VITE_SYNC_SERVER_URL) {
-  throw new Error('VITE_SYNC_SERVER_URL not set')
-}
-
 const appContextValue = {
   type: 'electron-client' as const,
   ipc: new IpcService(),
+}
+
+function getRemoteSyncServerUrl(): string | undefined {
+  // Settings are written by core's SettingsProvider under this key.
+  const settings = JSON.parse(localStorage.getItem('settings') ?? '{}') as {
+    syncServerMode?: string
+    remoteSyncServerUrl?: string
+  }
+
+  const remoteUrl =
+    settings.remoteSyncServerUrl ?? import.meta.env.VITE_SYNC_SERVER_URL
+
+  return settings.syncServerMode === 'remote' ? remoteUrl : undefined
+}
+
+function ElectronAppRoot() {
+  const [syncServerUrl, setSyncServerUrl] = useState<string | null>(
+    () => getRemoteSyncServerUrl() ?? null,
+  )
+
+  useEffect(() => {
+    if (syncServerUrl) {
+      return
+    }
+
+    appContextValue.ipc
+      .send<SyncServerInfo>('sync:get-server-info')
+      .then((info) => {
+        if (info.running) {
+          setSyncServerUrl(info.url)
+          return
+        }
+        const fallbackUrl = import.meta.env.VITE_SYNC_SERVER_URL
+        if (fallbackUrl) {
+          setSyncServerUrl(fallbackUrl)
+          return
+        }
+        console.error('Embedded sync server is not running')
+      })
+  }, [syncServerUrl])
+
+  if (!syncServerUrl) {
+    return null
+  }
+
+  return <App appContextValue={appContextValue} syncServerUrl={syncServerUrl} />
 }
 
 const root = createRoot(rootElement)
@@ -40,10 +82,7 @@ root.render(
           zIndex: 999,
         }}
       />
-      <App
-        appContextValue={appContextValue}
-        syncServerUrl={import.meta.env.VITE_SYNC_SERVER_URL}
-      />
+      <ElectronAppRoot />
     </div>
   </StrictMode>,
 )

--- a/apps/electron-client/src/syncServer.ts
+++ b/apps/electron-client/src/syncServer.ts
@@ -1,0 +1,164 @@
+import http from 'http'
+import os from 'os'
+import { WebSocketServer } from 'ws'
+// The slim entrypoints + base64 WASM keep the Automerge core inside the
+// bundled JS, so nothing has to resolve .wasm files from inside the asar.
+import { Repo, type PeerId } from '@automerge/automerge-repo/slim'
+import {
+  initializeBase64Wasm,
+  isWasmInitialized,
+} from '@automerge/automerge/slim'
+import { automergeWasmBase64 } from '@automerge/automerge/automerge.wasm.base64'
+import { WebSocketServerAdapter } from '@automerge/automerge-repo-network-websocket'
+import { NodeFSStorageAdapter } from '@automerge/automerge-repo-storage-nodefs'
+
+export const DEFAULT_SYNC_SERVER_PORT = 9001
+
+export type SyncServerInfo = {
+  running: boolean
+  url: string
+  lanUrl?: string
+  port: number
+  host: string
+}
+
+export type SyncServerOptions = {
+  storagePath: string
+  host: '127.0.0.1' | '0.0.0.0'
+  port?: number
+  peerId: string
+}
+
+type RunningSyncServer = {
+  info: SyncServerInfo
+  repo: Repo
+  wss: WebSocketServer
+  server: http.Server
+}
+
+let current: RunningSyncServer | null = null
+
+export function getSyncServerInfo(): SyncServerInfo {
+  return (
+    current?.info ?? {
+      running: false,
+      url: '',
+      port: 0,
+      host: '',
+    }
+  )
+}
+
+export function getLocalNetworkIp(): string | undefined {
+  const interfaces = os.networkInterfaces()
+  for (const addresses of Object.values(interfaces)) {
+    for (const address of addresses ?? []) {
+      if (address.family === 'IPv4' && !address.internal) {
+        return address.address
+      }
+    }
+  }
+  return undefined
+}
+
+function listen(server: http.Server, host: string, port: number) {
+  return new Promise<number>((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.removeListener('listening', onListening)
+      reject(error)
+    }
+    const onListening = () => {
+      server.removeListener('error', onError)
+      const address = server.address()
+      if (address === null || typeof address === 'string') {
+        reject(new Error('Sync server address unavailable'))
+        return
+      }
+      resolve(address.port)
+    }
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port, host)
+  })
+}
+
+export async function startSyncServer(
+  options: SyncServerOptions,
+): Promise<SyncServerInfo> {
+  if (current) {
+    return current.info
+  }
+
+  if (!isWasmInitialized()) {
+    await initializeBase64Wasm(automergeWasmBase64)
+  }
+
+  const { storagePath, host, peerId } = options
+  const requestedPort = options.port ?? DEFAULT_SYNC_SERVER_PORT
+
+  const server = http.createServer((_request, response) => {
+    response.writeHead(200, { 'Content-Type': 'text/plain' })
+    response.end('tapes-sync-server')
+  })
+
+  let port: number
+  try {
+    port = await listen(server, host, requestedPort)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE') {
+      throw error
+    }
+    // The renderer always receives the URL over IPC, so a fallback to an
+    // OS-assigned port is safe.
+    port = await listen(server, host, 0)
+  }
+
+  const wss = new WebSocketServer({ server })
+
+  // The adapter types its server via isomorphic-ws, which is the same ws
+  // class at runtime but a structurally incompatible type.
+  const adapterServer = wss as unknown as ConstructorParameters<
+    typeof WebSocketServerAdapter
+  >[0]
+
+  const repo = new Repo({
+    network: [new WebSocketServerAdapter(adapterServer)],
+    storage: new NodeFSStorageAdapter(storagePath),
+    peerId: peerId as PeerId,
+    sharePolicy: async () => false,
+  })
+
+  const lanIp = host === '0.0.0.0' ? getLocalNetworkIp() : undefined
+
+  current = {
+    info: {
+      running: true,
+      url: `ws://127.0.0.1:${port}`,
+      lanUrl: lanIp ? `ws://${lanIp}:${port}` : undefined,
+      port,
+      host,
+    },
+    repo,
+    wss,
+    server,
+  }
+
+  console.log(`Sync server listening on ws://${host}:${port}`)
+
+  return current.info
+}
+
+export async function stopSyncServer(): Promise<void> {
+  if (!current) {
+    return
+  }
+  const { repo, wss, server } = current
+  current = null
+
+  await repo.flush()
+  for (const client of wss.clients) {
+    client.terminate()
+  }
+  await new Promise<void>((resolve) => wss.close(() => resolve()))
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+}

--- a/apps/electron-client/src/syncServerConfig.ts
+++ b/apps/electron-client/src/syncServerConfig.ts
@@ -1,0 +1,39 @@
+import crypto from 'crypto'
+import path from 'path'
+import { readFileSync, writeFileSync } from 'fs'
+import { app } from 'electron'
+
+export type SyncServerConfig = {
+  peerId: string
+  lanEnabled: boolean
+}
+
+const configFilePath = () =>
+  path.join(app.getPath('userData'), 'sync-server.json')
+
+export const syncStoragePath = () =>
+  path.join(app.getPath('userData'), 'sync-storage')
+
+export function readSyncServerConfig(): SyncServerConfig {
+  try {
+    const stored = JSON.parse(
+      readFileSync(configFilePath(), 'utf-8'),
+    ) as Partial<SyncServerConfig>
+    if (typeof stored.peerId === 'string') {
+      return { peerId: stored.peerId, lanEnabled: stored.lanEnabled === true }
+    }
+  } catch {
+    // Missing or corrupt config falls through to defaults.
+  }
+
+  const config: SyncServerConfig = {
+    peerId: `tapes-embedded-${crypto.randomUUID()}`,
+    lanEnabled: false,
+  }
+  writeSyncServerConfig(config)
+  return config
+}
+
+export function writeSyncServerConfig(config: SyncServerConfig) {
+  writeFileSync(configFilePath(), JSON.stringify(config, null, 2))
+}

--- a/apps/electron-client/vite.main.config.ts
+++ b/apps/electron-client/vite.main.config.ts
@@ -1,4 +1,14 @@
 import { defineConfig } from 'vite'
+import wasm from 'vite-plugin-wasm'
+import topLevelAwait from 'vite-plugin-top-level-await'
 
 // https://vitejs.dev/config
-export default defineConfig({})
+export default defineConfig({
+  // The Automerge packages used by the embedded sync server are ESM with a
+  // WASM core; resolve their Node entrypoints and inline the WASM so the
+  // bundle works from inside the packaged app's asar.
+  resolve: {
+    conditions: ['node'],
+  },
+  plugins: [wasm(), topLevelAwait()],
+})

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -18,6 +18,16 @@ export type ValidIpcChanel =
   | 'storage:delete-recording'
   | 'recorder:start'
   | 'recorder:stop'
+  | 'sync:get-server-info'
+  | 'sync:set-lan-enabled'
+
+export type SyncServerInfo = {
+  running: boolean
+  url: string
+  lanUrl?: string
+  port: number
+  host: string
+}
 
 type IpcRequest = {
   responseChannel?: string
@@ -83,6 +93,8 @@ type IpcSendArgs =
       },
     ]
   | ['recorder:stop', IpcRequest]
+  | ['sync:get-server-info']
+  | ['sync:set-lan-enabled', IpcRequest & { data: { enabled: boolean } }]
 export class IpcService {
   private ipcRenderer?: Window['api']
 

--- a/packages/core/app/context/SettingsContext.tsx
+++ b/packages/core/app/context/SettingsContext.tsx
@@ -6,6 +6,9 @@ type Settings = {
   audioChannelCount: '1' | '2' | undefined
   storageLocation: string | undefined
   automergeUrl: string | undefined
+  syncServerMode: 'embedded' | 'remote' | undefined
+  remoteSyncServerUrl: string | undefined
+  syncServerLanEnabled: 'true' | 'false' | undefined
 }
 
 const SettingsContext = createContext<{

--- a/packages/core/app/views/Settings.tsx
+++ b/packages/core/app/views/Settings.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   MdOutlineContentCopy,
   MdOutlineFileUpload,
@@ -11,6 +11,7 @@ import { useAppContext } from '@/context/AppContext'
 import { Button, TextInput } from '@tapes-monorepo/ui'
 import { isValidAutomergeUrl } from '@automerge/automerge-repo'
 import { useAutomergeUrl } from '@/utils'
+import { SyncServerInfo } from '@/IpcService'
 
 export function Settings() {
   const appContext = useAppContext()
@@ -116,6 +117,7 @@ export function Settings() {
           </div>
         </div>
       )}
+      {appContext.type === 'electron-client' && <SyncSettings />}
       <div className="flex flex-col gap-2">
         <h2>Data</h2>
         <div className="flex flex-col gap-2 p-2">
@@ -177,6 +179,150 @@ export function Settings() {
           </div>
         </div>
       </div>
+    </div>
+  )
+}
+
+function SyncSettings() {
+  const appContext = useAppContext()
+  const [syncServerMode, setSyncServerMode] = useSetting('syncServerMode')
+  const [remoteSyncServerUrl, setRemoteSyncServerUrl] = useSetting(
+    'remoteSyncServerUrl',
+  )
+  const [syncServerLanEnabled, setSyncServerLanEnabled] = useSetting(
+    'syncServerLanEnabled',
+  )
+  const [remoteUrlDraft, setRemoteUrlDraft] = useState(
+    remoteSyncServerUrl ?? '',
+  )
+  const [serverInfo, setServerInfo] = useState<SyncServerInfo | null>(null)
+
+  const mode = syncServerMode ?? 'embedded'
+
+  useEffect(() => {
+    if (appContext.type !== 'electron-client' || mode !== 'embedded') {
+      return
+    }
+    appContext.ipc
+      .send<SyncServerInfo>('sync:get-server-info')
+      .then(setServerInfo)
+  }, [appContext, mode])
+
+  if (appContext.type !== 'electron-client') {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <h2>Sync</h2>
+      <label className="flex flex-col gap-2 text-sm">
+        <h3>Sync server:</h3>
+        <select
+          className="flex appearance-none items-center justify-center rounded-sm bg-transparent p-2 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+          onChange={(event) => {
+            const value = event.target.value as 'embedded' | 'remote'
+            setSyncServerMode(value)
+            if (value === 'embedded' || remoteSyncServerUrl) {
+              window.location.reload()
+            }
+          }}
+          defaultValue={mode}
+        >
+          <option value="embedded">This device (built-in)</option>
+          <option value="remote">Remote server</option>
+        </select>
+      </label>
+      {mode === 'remote' && (
+        <div className="flex w-full items-center justify-between gap-5 text-sm">
+          <TextInput
+            label="Remote sync server URL"
+            type="text"
+            name="remote-sync-server-url"
+            id="remote-sync-server-url"
+            value={remoteUrlDraft}
+            onChange={(event) => setRemoteUrlDraft(event.target.value)}
+            validate={(value) => {
+              try {
+                const url = new URL(value)
+                if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+                  return 'Must be a ws:// or wss:// URL'
+                }
+                return undefined
+              } catch {
+                return 'Invalid URL'
+              }
+            }}
+          />
+          <Button
+            className="w-fit p-2"
+            title="Save sync server URL"
+            onClick={() => {
+              try {
+                const url = new URL(remoteUrlDraft)
+                if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+                  return
+                }
+              } catch {
+                return
+              }
+              setRemoteSyncServerUrl(remoteUrlDraft)
+              window.location.reload()
+            }}
+          >
+            Save
+          </Button>
+        </div>
+      )}
+      {mode === 'embedded' && (
+        <div className="flex flex-col gap-2 text-sm">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={syncServerLanEnabled === 'true'}
+              onChange={async (event) => {
+                const enabled = event.target.checked
+                const info = (await appContext.ipc.send<
+                  SyncServerInfo | undefined
+                >('sync:set-lan-enabled', {
+                  data: { enabled },
+                })) as SyncServerInfo | undefined
+
+                if (!info) {
+                  console.error('No response from sync:set-lan-enabled')
+                  return
+                }
+
+                setSyncServerLanEnabled(enabled ? 'true' : 'false')
+                setServerInfo(info)
+              }}
+            />
+            Share with other devices on this network
+          </label>
+          <p className="pl-2 text-xs text-zinc-500">
+            Anyone on your local network can connect to the sync server while
+            this is enabled. Devices served over HTTPS (like the hosted web
+            client) cannot connect to a local ws:// address.
+          </p>
+          {syncServerLanEnabled === 'true' && serverInfo?.lanUrl && (
+            <div className="flex items-center gap-2 pl-2">
+              <p className="truncate text-xs" title={serverInfo.lanUrl}>
+                {serverInfo.lanUrl}
+              </p>
+              <Button
+                className="w-fit rounded-full p-2"
+                title="Copy sync server URL to clipboard"
+                onClick={() => {
+                  if (serverInfo.lanUrl) {
+                    navigator.clipboard.writeText(serverInfo.lanUrl)
+                  }
+                }}
+              >
+                <MdOutlineContentCopy />
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -165,10 +165,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@automerge/automerge@npm:2.2.8 - 3":
-  version: 3.3.1
-  resolution: "@automerge/automerge@npm:3.3.1"
-  checksum: 10c0/a0c113bdb1e5fd59cba06c2985a35164b4ce88a9f1f2613b9e5ef66233c746abd5952de46308aecb35461642fa011ebc0a49ed9d9e22d1e6f5b61b11cb3e5d84
+"@automerge/automerge@npm:2.2.8 - 3, @automerge/automerge@npm:^3.0.0":
+  version: 3.3.2
+  resolution: "@automerge/automerge@npm:3.3.2"
+  checksum: 10c0/4a191afa935575478d487184c8309483384d5c830f932a6f2ef4c23e5be525658eb0425fe8e08c0f0226823117bf7af719382100e222ff83aa8d44bc44d34f21
   languageName: node
   linkType: hard
 
@@ -7975,6 +7975,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "electron-client@workspace:apps/electron-client"
   dependencies:
+    "@automerge/automerge": "npm:^3.0.0"
+    "@automerge/automerge-repo": "npm:^2.0.0"
+    "@automerge/automerge-repo-network-websocket": "npm:^2.0.0"
+    "@automerge/automerge-repo-storage-nodefs": "npm:^2.0.0"
     "@dotenvx/dotenvx": "npm:^2.0.0"
     "@electron-forge/cli": "npm:^7.6.0"
     "@electron-forge/maker-deb": "npm:^7.6.0"
@@ -7997,6 +8001,7 @@ __metadata:
     "@types/node": "npm:^24.0.0"
     "@types/react": "npm:^19.0.1"
     "@types/react-dom": "npm:^19.0.1"
+    "@types/ws": "npm:^8.5.13"
     "@typescript-eslint/eslint-plugin": "npm:^8.0.0"
     "@typescript-eslint/parser": "npm:^8.0.0"
     "@vitejs/plugin-react": "npm:^6.0.3"
@@ -8020,6 +8025,7 @@ __metadata:
     vite-plugin-require: "npm:^1.2.14"
     vite-plugin-top-level-await: "npm:^1.6.0"
     vite-plugin-wasm: "npm:^3.6.0"
+    ws: "npm:^8.18.0"
   peerDependencies:
     esbuild-register: "*"
     ts-node: "*"


### PR DESCRIPTION
Runs the Automerge sync server (previously only available via the separately deployed `apps/api` NestJS service) inside the Electron main process, so the desktop app works without a remote server. Tracked in Linear: TAP-55.

## What changed

- **`src/syncServer.ts`** — direct Repo embed: `http` server + `ws` WebSocketServer + Automerge `Repo` (`WebSocketServerAdapter` + `NodeFSStorageAdapter`), mirroring the api sync gateway's semantics (`sharePolicy: () => false`). Uses the slim entrypoints with base64-inlined WASM so the bundle needs no `.wasm` file resolution from inside the packaged asar. Port 9001 by default, falling back to an OS-assigned port when taken.
- **Storage/config** — doc storage in `userData/sync-storage`; a per-install random peerId and the LAN flag persist in `userData/sync-server.json` (`syncServerConfig.ts`).
- **Lifecycle** — starts on app ready next to the existing cache server; on `will-quit` the repo is flushed to disk before exit so no doc data is lost.
- **IPC** — new `sync:get-server-info` and `sync:set-lan-enabled` channels following the existing channel pattern (registered in `index.ts`, allowlisted in `preload.ts`, typed in core's `IpcService`).
- **Renderer** — resolves the sync server URL at runtime over IPC instead of requiring `VITE_SYNC_SERVER_URL` at build time (the env var remains as an optional fallback/seed). `apps/web-client` is unchanged.
- **Settings** — electron-only "Sync" section: embedded vs remote server mode (remote takes a `ws(s)://` URL, so the deployed api still works), plus an opt-in LAN toggle that surfaces the copyable `ws://<lan-ip>:9001` URL for other devices.
- **Build** — `vite.main.config.ts` gains node resolve conditions + wasm/top-level-await plugins; `@automerge/automerge` deduped to a single copy (two instances break WASM init with `Automerge.use() not called`).

`apps/api` is untouched and remains deployable for the cloud/`wss://` path.

## Verification

- Type-checks pass for `core`, `electron-client`, and `web-client`; lint clean.
- The sync server was bundled through a config replicating Forge's exact main-process Vite settings and exercised end-to-end: client A created a doc → the server persisted it to disk → a fresh client B fetched it back through the server → the doc survived a server restart and was fetched again.
- Not yet verified (needs a real machine, see TAP-55): packaged-app run (`yarn workspace electron-client package`), LAN sync with a second device, remote mode against the deployed api.

## Known limitations

- Switching sync mode/URL triggers a page reload rather than rebuilding the Repo live (core `App.tsx` guards initialization with `didInitRef`; intentionally not refactored here).
- An HTTPS-served web client cannot connect to a plain `ws://` LAN host (browser mixed-content policy) — noted in the Settings UI copy; HTTPS clients keep using `apps/api` over `wss://`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016b1ecVCpUizrDbdNeABmNV

---
_Generated by [Claude Code](https://claude.ai/code/session_016b1ecVCpUizrDbdNeABmNV)_