### PR TITLE
feat(electron-client): host the web-client from the Electron client for LAN devices (TAP-56)

### DIFF
--- a/apps/electron-client/.gitignore
+++ b/apps/electron-client/.gitignore
@@ -97,6 +97,9 @@ bin/*
 cache/*
 !cache/.gitkeep
 
+web-client/*
+!web-client/.gitkeep
+
 downloadExecutables.js
 .vercel
 .env*.local

--- a/apps/electron-client/eslint.config.mjs
+++ b/apps/electron-client/eslint.config.mjs
@@ -4,6 +4,6 @@ import { config } from "@tapes-monorepo/eslint-config/react-internal";
 export default [
   ...config,
   {
-    ignores: [".vite/**", "downloadExecutables.js"],
+    ignores: [".vite/**", "web-client/**", "downloadExecutables.js"],
   },
 ];

--- a/apps/electron-client/forge.config.ts
+++ b/apps/electron-client/forge.config.ts
@@ -28,6 +28,9 @@ const config: ForgeConfig = {
       'bin/sox-14.4.2-macOS',
       'bin/SwitchAudioSource-1.2.2-macOS',
       'cache',
+      // Built web-client bundle, staged by the `stage-web-client` script and
+      // served to LAN guests by the embedded sync server (see syncServer.ts).
+      'web-client',
     ],
   },
   publishers: [

--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -38,6 +38,7 @@
     "@types/node": "^24.0.0",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.1",
+    "@types/selfsigned": "^2.1.0",
     "@types/ws": "^8.5.13",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
@@ -87,7 +88,7 @@
     "node-stream-zip": "^1.15.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "selfsigned": "^5.5.0",
+    "selfsigned": "^2.4.1",
     "update-electron-app": "^3.1.0",
     "ws": "^8.18.0"
   }

--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -87,6 +87,7 @@
     "node-stream-zip": "^1.15.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "selfsigned": "^5.5.0",
     "update-electron-app": "^3.1.0",
     "ws": "^8.18.0"
   }

--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -8,9 +8,10 @@
   "scripts": {
     "get-bin": "tsc downloadExecutables.ts && node downloadExecutables.js",
     "dev": "LOCAL_NETWORK_IP=\"$(ipconfig getifaddr en0)\" dotenvx run --env-file=.env.local -- electron-forge start -- --trace-warnings",
-    "package": "dotenvx run --env-file=.env -- electron-forge package",
-    "make": "dotenvx run --env-file=.env -- electron-forge make",
-    "publish": "dotenvx run --env-file=.env -- electron-forge publish",
+    "stage-web-client": "yarn workspace web-client build && find web-client -mindepth 1 ! -name .gitkeep -delete && cp -R ../web-client/dist/. web-client/",
+    "package": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge package",
+    "make": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge make",
+    "publish": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge publish",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",
     "clean": "rm -rf .vite",

--- a/apps/electron-client/src/certManager.ts
+++ b/apps/electron-client/src/certManager.ts
@@ -22,33 +22,25 @@ function readMeta(): CertMeta | null {
   }
 }
 
-async function generateCert(lanIp: string | undefined): Promise<TlsMaterial> {
-  // type 2 = DNS name, type 7 = IP address (see selfsigned SubjectAltName).
-  const altNames = [
-    { type: 2 as const, value: 'localhost' },
-    { type: 7 as const, ip: '127.0.0.1' },
+function generateCert(lanIp: string | undefined): TlsMaterial {
+  // type 2 = DNS name, type 7 = IP address (see node-forge altNames).
+  const altNames: Array<{ type: number; value?: string; ip?: string }> = [
+    { type: 2, value: 'localhost' },
+    { type: 7, ip: '127.0.0.1' },
   ]
   if (lanIp) {
-    altNames.push({ type: 7 as const, ip: lanIp })
+    altNames.push({ type: 7, ip: lanIp })
   }
 
-  const notBeforeDate = new Date()
-  const notAfterDate = new Date(notBeforeDate)
-  notAfterDate.setFullYear(notAfterDate.getFullYear() + 10)
-
-  const pems = await generate(
-    [{ name: 'commonName', value: lanIp ?? 'localhost' }],
-    {
-      keySize: 2048,
-      algorithm: 'sha256',
-      notBeforeDate,
-      notAfterDate,
-      extensions: [
-        { name: 'basicConstraints', cA: false },
-        { name: 'subjectAltName', altNames },
-      ],
-    },
-  )
+  const pems = generate([{ name: 'commonName', value: lanIp ?? 'localhost' }], {
+    keySize: 2048,
+    algorithm: 'sha256',
+    days: 3650,
+    extensions: [
+      { name: 'basicConstraints', cA: false },
+      { name: 'subjectAltName', altNames },
+    ],
+  })
 
   return { key: pems.private, cert: pems.cert }
 }
@@ -59,9 +51,7 @@ async function generateCert(lanIp: string | undefined): Promise<TlsMaterial> {
  * IP changes. Persisting the cert means a guest's accepted browser exception
  * survives app restarts. `key.pem`/`cert.pem` live under `userData/sync-tls`.
  */
-export async function ensureSyncServerCert(
-  lanIp: string | undefined,
-): Promise<TlsMaterial> {
+export function ensureSyncServerCert(lanIp: string | undefined): TlsMaterial {
   mkdirSync(certDir(), { recursive: true })
 
   const meta = readMeta()
@@ -72,7 +62,7 @@ export async function ensureSyncServerCert(
     }
   }
 
-  const material = await generateCert(lanIp)
+  const material = generateCert(lanIp)
   writeFileSync(keyPath(), material.key)
   writeFileSync(certPath(), material.cert)
   writeFileSync(metaPath(), JSON.stringify({ lanIp }, null, 2))

--- a/apps/electron-client/src/certManager.ts
+++ b/apps/electron-client/src/certManager.ts
@@ -1,0 +1,93 @@
+import path from 'path'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
+import { app } from 'electron'
+import { generate } from 'selfsigned'
+
+export type TlsMaterial = { key: string; cert: string }
+
+const certDir = () => path.join(app.getPath('userData'), 'sync-tls')
+const keyPath = () => path.join(certDir(), 'key.pem')
+const certPath = () => path.join(certDir(), 'cert.pem')
+const metaPath = () => path.join(certDir(), 'cert-meta.json')
+
+// The LAN IP the persisted cert was minted for, so we can regenerate when it
+// changes (the IP must be in the SAN for https://<lan-ip> to validate).
+type CertMeta = { lanIp?: string }
+
+function readMeta(): CertMeta | null {
+  try {
+    return JSON.parse(readFileSync(metaPath(), 'utf-8')) as CertMeta
+  } catch {
+    return null
+  }
+}
+
+async function generateCert(lanIp: string | undefined): Promise<TlsMaterial> {
+  // type 2 = DNS name, type 7 = IP address (see selfsigned SubjectAltName).
+  const altNames = [
+    { type: 2 as const, value: 'localhost' },
+    { type: 7 as const, ip: '127.0.0.1' },
+  ]
+  if (lanIp) {
+    altNames.push({ type: 7 as const, ip: lanIp })
+  }
+
+  const notBeforeDate = new Date()
+  const notAfterDate = new Date(notBeforeDate)
+  notAfterDate.setFullYear(notAfterDate.getFullYear() + 10)
+
+  const pems = await generate(
+    [{ name: 'commonName', value: lanIp ?? 'localhost' }],
+    {
+      keySize: 2048,
+      algorithm: 'sha256',
+      notBeforeDate,
+      notAfterDate,
+      extensions: [
+        { name: 'basicConstraints', cA: false },
+        { name: 'subjectAltName', altNames },
+      ],
+    },
+  )
+
+  return { key: pems.private, cert: pems.cert }
+}
+
+/**
+ * Returns the TLS key+cert for the embedded sync server, generating and
+ * persisting a self-signed cert on first run and regenerating it when the LAN
+ * IP changes. Persisting the cert means a guest's accepted browser exception
+ * survives app restarts. `key.pem`/`cert.pem` live under `userData/sync-tls`.
+ */
+export async function ensureSyncServerCert(
+  lanIp: string | undefined,
+): Promise<TlsMaterial> {
+  mkdirSync(certDir(), { recursive: true })
+
+  const meta = readMeta()
+  if (existsSync(keyPath()) && existsSync(certPath()) && meta?.lanIp === lanIp) {
+    return {
+      key: readFileSync(keyPath(), 'utf-8'),
+      cert: readFileSync(certPath(), 'utf-8'),
+    }
+  }
+
+  const material = await generateCert(lanIp)
+  writeFileSync(keyPath(), material.key)
+  writeFileSync(certPath(), material.cert)
+  writeFileSync(metaPath(), JSON.stringify({ lanIp }, null, 2))
+  return material
+}
+
+/**
+ * The persisted sync-server cert PEM, or null if none has been generated yet.
+ * Used by the main process to trust exactly this cert when the host's own
+ * renderer connects to the embedded server over `wss://127.0.0.1`.
+ */
+export function getSyncServerCertPem(): string | null {
+  try {
+    return readFileSync(certPath(), 'utf-8')
+  } catch {
+    return null
+  }
+}

--- a/apps/electron-client/src/channels/SetSyncServerHttpsChannel.ts
+++ b/apps/electron-client/src/channels/SetSyncServerHttpsChannel.ts
@@ -3,8 +3,8 @@ import { IpcChannel, IpcRequest } from '@/types'
 import { readSyncServerConfig, writeSyncServerConfig } from '@/syncServerConfig'
 import { restartSyncServerFromConfig } from '@/syncServerRuntime'
 
-export class SetSyncServerLanChannel implements IpcChannel {
-  name = 'sync:set-lan-enabled'
+export class SetSyncServerHttpsChannel implements IpcChannel {
+  name = 'sync:set-https-enabled'
   async handle(event: IpcMainEvent, request: IpcRequest) {
     const { responseChannel } = request
     if (!responseChannel) {
@@ -13,13 +13,16 @@ export class SetSyncServerLanChannel implements IpcChannel {
 
     try {
       const { enabled } = request.data as { enabled: boolean }
-      writeSyncServerConfig({ ...readSyncServerConfig(), lanEnabled: enabled })
+      writeSyncServerConfig({
+        ...readSyncServerConfig(),
+        httpsEnabled: enabled,
+      })
 
       const info = await restartSyncServerFromConfig()
 
       event.sender.send(responseChannel, info)
     } catch (error) {
-      console.error('Failed to switch sync server binding:', error)
+      console.error('Failed to switch sync server TLS:', error)
       event.sender.send(responseChannel, undefined)
     }
   }

--- a/apps/electron-client/src/channels/SetSyncServerLanChannel.ts
+++ b/apps/electron-client/src/channels/SetSyncServerLanChannel.ts
@@ -4,6 +4,7 @@ import { startSyncServer, stopSyncServer } from '@/syncServer'
 import {
   readSyncServerConfig,
   syncStoragePath,
+  webClientPath,
   writeSyncServerConfig,
 } from '@/syncServerConfig'
 
@@ -25,6 +26,7 @@ export class SetSyncServerLanChannel implements IpcChannel {
         storagePath: syncStoragePath(),
         host: enabled ? '0.0.0.0' : '127.0.0.1',
         peerId: config.peerId,
+        webClientPath: webClientPath(),
       })
 
       event.sender.send(responseChannel, info)

--- a/apps/electron-client/src/index.ts
+++ b/apps/electron-client/src/index.ts
@@ -5,6 +5,7 @@ import { GetSyncServerInfoChannel } from './channels/GetSyncServerInfoChannel'
 import { OpenDirectoryDialogChannel } from './channels/OpenDirectoryDialogChannel'
 import { SetDefaultAudioInputChannel } from './channels/SetDefaultAudioInputChannel'
 import { SetSyncServerLanChannel } from './channels/SetSyncServerLanChannel'
+import { SetSyncServerHttpsChannel } from './channels/SetSyncServerHttpsChannel'
 import { MainWindow } from './main'
 
 new MainWindow().init([
@@ -15,4 +16,5 @@ new MainWindow().init([
   new SetDefaultAudioInputChannel(),
   new GetSyncServerInfoChannel(),
   new SetSyncServerLanChannel(),
+  new SetSyncServerHttpsChannel(),
 ])

--- a/apps/electron-client/src/main.ts
+++ b/apps/electron-client/src/main.ts
@@ -9,12 +9,9 @@ import installExtension, {
 import { updateElectronApp } from 'update-electron-app'
 import { IpcChannel } from './types'
 import { cacheServer } from './cacheServer'
-import { startSyncServer, stopSyncServer } from './syncServer'
-import {
-  readSyncServerConfig,
-  syncStoragePath,
-  webClientPath,
-} from './syncServerConfig'
+import { stopSyncServer } from './syncServer'
+import { startSyncServerFromConfig } from './syncServerRuntime'
+import { getSyncServerCertPem } from './certManager'
 
 updateElectronApp()
 
@@ -42,7 +39,25 @@ export class MainWindow {
     app.on('window-all-closed', this.onWindowAllClosed)
     app.on('activate', this.onActivate)
     app.on('will-quit', this.onWillQuit)
+    this.registerSyncServerCertTrust()
     this.registerIpcChannels(ipcChannels)
+  }
+
+  // When the embedded sync server runs over HTTPS, the host's own renderer
+  // connects to it at `wss://127.0.0.1` with our self-signed cert. Trust
+  // exactly that cert (by PEM match) so the loopback connection succeeds
+  // without disabling verification for anything else.
+  private registerSyncServerCertTrust() {
+    const normalize = (pem: string) => pem.replace(/\s+/g, '')
+    app.on('certificate-error', (event, _webContents, _url, _error, cert, callback) => {
+      const ourCert = getSyncServerCertPem()
+      if (ourCert && cert.data && normalize(cert.data) === normalize(ourCert)) {
+        event.preventDefault()
+        callback(true)
+        return
+      }
+      callback(false)
+    })
   }
 
   private async createWindow() {
@@ -115,13 +130,7 @@ export class MainWindow {
 
   private async startSyncServer() {
     try {
-      const config = readSyncServerConfig()
-      await startSyncServer({
-        storagePath: syncStoragePath(),
-        host: config.lanEnabled ? '0.0.0.0' : '127.0.0.1',
-        peerId: config.peerId,
-        webClientPath: webClientPath(),
-      })
+      await startSyncServerFromConfig()
     } catch (error) {
       console.error('Failed to start sync server:', error)
     }

--- a/apps/electron-client/src/main.ts
+++ b/apps/electron-client/src/main.ts
@@ -10,7 +10,11 @@ import { updateElectronApp } from 'update-electron-app'
 import { IpcChannel } from './types'
 import { cacheServer } from './cacheServer'
 import { startSyncServer, stopSyncServer } from './syncServer'
-import { readSyncServerConfig, syncStoragePath } from './syncServerConfig'
+import {
+  readSyncServerConfig,
+  syncStoragePath,
+  webClientPath,
+} from './syncServerConfig'
 
 updateElectronApp()
 
@@ -116,6 +120,7 @@ export class MainWindow {
         storagePath: syncStoragePath(),
         host: config.lanEnabled ? '0.0.0.0' : '127.0.0.1',
         peerId: config.peerId,
+        webClientPath: webClientPath(),
       })
     } catch (error) {
       console.error('Failed to start sync server:', error)

--- a/apps/electron-client/src/preload.ts
+++ b/apps/electron-client/src/preload.ts
@@ -13,6 +13,7 @@ const validChannels: ValidIpcChanel[] = [
   'recorder:stop',
   'sync:get-server-info',
   'sync:set-lan-enabled',
+  'sync:set-https-enabled',
 ]
 
 const validResponseChannels = validChannels.map(

--- a/apps/electron-client/src/syncServer.ts
+++ b/apps/electron-client/src/syncServer.ts
@@ -1,5 +1,7 @@
 import http from 'http'
 import os from 'os'
+import path from 'path'
+import { readFile } from 'fs/promises'
 import { WebSocketServer } from 'ws'
 // The slim entrypoints + base64 WASM keep the Automerge core inside the
 // bundled JS, so nothing has to resolve .wasm files from inside the asar.
@@ -18,6 +20,10 @@ export type SyncServerInfo = {
   running: boolean
   url: string
   lanUrl?: string
+  /** URL of the hosted web-client bundle, when one is being served. */
+  webAppUrl?: string
+  /** LAN-reachable URL of the hosted web-client bundle. */
+  lanWebAppUrl?: string
   port: number
   host: string
 }
@@ -27,6 +33,12 @@ export type SyncServerOptions = {
   host: '127.0.0.1' | '0.0.0.0'
   port?: number
   peerId: string
+  /**
+   * Directory of the built web-client bundle to serve statically over the
+   * same origin as the sync socket. When omitted, the HTTP surface is just a
+   * health-check and only the WebSocket sync endpoint is exposed.
+   */
+  webClientPath?: string
 }
 
 type RunningSyncServer = {
@@ -61,6 +73,82 @@ export function getLocalNetworkIp(): string | undefined {
   return undefined
 }
 
+const STATIC_MIME_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.wasm': 'application/wasm',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webmanifest': 'application/manifest+json',
+}
+
+/**
+ * Builds the HTTP request handler. When `webClientPath` is set it serves the
+ * built web-client bundle (with an SPA fallback to index.html so deep links
+ * like `/?am=<url>` work); otherwise it responds with a plain health check.
+ */
+function createRequestHandler(webClientPath?: string) {
+  return async (
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ) => {
+    if (!webClientPath) {
+      response.writeHead(200, { 'Content-Type': 'text/plain' })
+      response.end('tapes-sync-server')
+      return
+    }
+
+    const root = path.resolve(webClientPath)
+    const indexPath = path.join(root, 'index.html')
+
+    const requestUrl = new URL(request.url ?? '/', 'http://localhost')
+    const requestedPath = path.normalize(
+      decodeURIComponent(requestUrl.pathname),
+    )
+    const candidate = path.join(root, requestedPath)
+
+    // Guard against path traversal outside the served directory.
+    const filePath =
+      candidate === root || candidate.startsWith(root + path.sep)
+        ? candidate
+        : indexPath
+
+    const serve = async (target: string) => {
+      const data = await readFile(target)
+      const ext = path.extname(target).toLowerCase()
+      response.writeHead(200, {
+        'Content-Type': STATIC_MIME_TYPES[ext] ?? 'application/octet-stream',
+      })
+      response.end(data)
+    }
+
+    try {
+      await serve(filePath)
+    } catch {
+      // Missing file, directory, or SPA route -> fall back to index.html.
+      try {
+        await serve(indexPath)
+      } catch {
+        response.writeHead(404, { 'Content-Type': 'text/plain' })
+        response.end('Not found')
+      }
+    }
+  }
+}
+
 function listen(server: http.Server, host: string, port: number) {
   return new Promise<number>((resolve, reject) => {
     const onError = (error: NodeJS.ErrnoException) => {
@@ -93,13 +181,10 @@ export async function startSyncServer(
     await initializeBase64Wasm(automergeWasmBase64)
   }
 
-  const { storagePath, host, peerId } = options
+  const { storagePath, host, peerId, webClientPath } = options
   const requestedPort = options.port ?? DEFAULT_SYNC_SERVER_PORT
 
-  const server = http.createServer((_request, response) => {
-    response.writeHead(200, { 'Content-Type': 'text/plain' })
-    response.end('tapes-sync-server')
-  })
+  const server = http.createServer(createRequestHandler(webClientPath))
 
   let port: number
   try {
@@ -135,6 +220,9 @@ export async function startSyncServer(
       running: true,
       url: `ws://127.0.0.1:${port}`,
       lanUrl: lanIp ? `ws://${lanIp}:${port}` : undefined,
+      webAppUrl: webClientPath ? `http://127.0.0.1:${port}` : undefined,
+      lanWebAppUrl:
+        webClientPath && lanIp ? `http://${lanIp}:${port}` : undefined,
       port,
       host,
     },

--- a/apps/electron-client/src/syncServer.ts
+++ b/apps/electron-client/src/syncServer.ts
@@ -1,4 +1,5 @@
 import http from 'http'
+import https from 'https'
 import os from 'os'
 import path from 'path'
 import { readFile } from 'fs/promises'
@@ -39,6 +40,13 @@ export type SyncServerOptions = {
    * health-check and only the WebSocket sync endpoint is exposed.
    */
   webClientPath?: string
+  /**
+   * Self-signed key+cert. When provided the server runs over HTTPS (and the
+   * sync socket over `wss://`) on the same port, so a guest gets a secure
+   * context — required for both recording and OPFS-backed playback — and the
+   * `wss://` handshake reuses the accepted cert exception (same origin).
+   */
+  tls?: { key: string; cert: string }
 }
 
 type RunningSyncServer = {
@@ -181,10 +189,13 @@ export async function startSyncServer(
     await initializeBase64Wasm(automergeWasmBase64)
   }
 
-  const { storagePath, host, peerId, webClientPath } = options
+  const { storagePath, host, peerId, webClientPath, tls } = options
   const requestedPort = options.port ?? DEFAULT_SYNC_SERVER_PORT
 
-  const server = http.createServer(createRequestHandler(webClientPath))
+  const handler = createRequestHandler(webClientPath)
+  const server = tls
+    ? https.createServer({ key: tls.key, cert: tls.cert }, handler)
+    : http.createServer(handler)
 
   let port: number
   try {
@@ -214,15 +225,17 @@ export async function startSyncServer(
   })
 
   const lanIp = host === '0.0.0.0' ? getLocalNetworkIp() : undefined
+  const wsScheme = tls ? 'wss' : 'ws'
+  const httpScheme = tls ? 'https' : 'http'
 
   current = {
     info: {
       running: true,
-      url: `ws://127.0.0.1:${port}`,
-      lanUrl: lanIp ? `ws://${lanIp}:${port}` : undefined,
-      webAppUrl: webClientPath ? `http://127.0.0.1:${port}` : undefined,
+      url: `${wsScheme}://127.0.0.1:${port}`,
+      lanUrl: lanIp ? `${wsScheme}://${lanIp}:${port}` : undefined,
+      webAppUrl: webClientPath ? `${httpScheme}://127.0.0.1:${port}` : undefined,
       lanWebAppUrl:
-        webClientPath && lanIp ? `http://${lanIp}:${port}` : undefined,
+        webClientPath && lanIp ? `${httpScheme}://${lanIp}:${port}` : undefined,
       port,
       host,
     },
@@ -231,7 +244,7 @@ export async function startSyncServer(
     server,
   }
 
-  console.log(`Sync server listening on ws://${host}:${port}`)
+  console.log(`Sync server listening on ${wsScheme}://${host}:${port}`)
 
   return current.info
 }

--- a/apps/electron-client/src/syncServerConfig.ts
+++ b/apps/electron-client/src/syncServerConfig.ts
@@ -6,6 +6,9 @@ import { app } from 'electron'
 export type SyncServerConfig = {
   peerId: string
   lanEnabled: boolean
+  // Serve the LAN over self-signed HTTPS so guests get a secure context
+  // (required for playback and recording, not just plain browsing).
+  httpsEnabled: boolean
 }
 
 const configFilePath = () =>
@@ -35,7 +38,11 @@ export function readSyncServerConfig(): SyncServerConfig {
       readFileSync(configFilePath(), 'utf-8'),
     ) as Partial<SyncServerConfig>
     if (typeof stored.peerId === 'string') {
-      return { peerId: stored.peerId, lanEnabled: stored.lanEnabled === true }
+      return {
+        peerId: stored.peerId,
+        lanEnabled: stored.lanEnabled === true,
+        httpsEnabled: stored.httpsEnabled === true,
+      }
     }
   } catch {
     // Missing or corrupt config falls through to defaults.
@@ -44,6 +51,7 @@ export function readSyncServerConfig(): SyncServerConfig {
   const config: SyncServerConfig = {
     peerId: `tapes-embedded-${crypto.randomUUID()}`,
     lanEnabled: false,
+    httpsEnabled: false,
   }
   writeSyncServerConfig(config)
   return config

--- a/apps/electron-client/src/syncServerConfig.ts
+++ b/apps/electron-client/src/syncServerConfig.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto'
 import path from 'path'
-import { readFileSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync } from 'fs'
 import { app } from 'electron'
 
 export type SyncServerConfig = {
@@ -13,6 +13,21 @@ const configFilePath = () =>
 
 export const syncStoragePath = () =>
   path.join(app.getPath('userData'), 'sync-storage')
+
+/**
+ * Resolves the directory of the bundled web-client, staged as an
+ * `extraResource` in production (see forge.config.ts) and read from the
+ * sibling package's `dist` in development. Returns `undefined` when no built
+ * bundle is present, so hosting is only advertised when it can actually work.
+ */
+export const webClientPath = (): string | undefined => {
+  const candidate =
+    process.env.NODE_ENV !== 'development'
+      ? path.resolve(process.resourcesPath, 'web-client')
+      : path.resolve(app.getAppPath(), '..', 'web-client', 'dist')
+
+  return existsSync(path.join(candidate, 'index.html')) ? candidate : undefined
+}
 
 export function readSyncServerConfig(): SyncServerConfig {
   try {

--- a/apps/electron-client/src/syncServerRuntime.ts
+++ b/apps/electron-client/src/syncServerRuntime.ts
@@ -1,0 +1,40 @@
+import {
+  getLocalNetworkIp,
+  startSyncServer,
+  stopSyncServer,
+  type SyncServerInfo,
+} from './syncServer'
+import {
+  readSyncServerConfig,
+  syncStoragePath,
+  webClientPath,
+} from './syncServerConfig'
+import { ensureSyncServerCert } from './certManager'
+
+/**
+ * Composes the persisted sync-server config into runtime options and starts
+ * the server: binds LAN-wide when sharing is on, and mints/loads a self-signed
+ * cert (with the current LAN IP in its SAN) when HTTPS is on. Shared by the app
+ * bootstrap and the IPC toggles so the option-building logic lives in one place.
+ */
+export async function startSyncServerFromConfig(): Promise<SyncServerInfo> {
+  const config = readSyncServerConfig()
+  const host = config.lanEnabled ? '0.0.0.0' : '127.0.0.1'
+  const lanIp = config.lanEnabled ? getLocalNetworkIp() : undefined
+  const tls = config.httpsEnabled
+    ? await ensureSyncServerCert(lanIp)
+    : undefined
+
+  return startSyncServer({
+    storagePath: syncStoragePath(),
+    host,
+    peerId: config.peerId,
+    webClientPath: webClientPath(),
+    tls,
+  })
+}
+
+export async function restartSyncServerFromConfig(): Promise<SyncServerInfo> {
+  await stopSyncServer()
+  return startSyncServerFromConfig()
+}

--- a/apps/electron-client/src/syncServerRuntime.ts
+++ b/apps/electron-client/src/syncServerRuntime.ts
@@ -21,9 +21,7 @@ export async function startSyncServerFromConfig(): Promise<SyncServerInfo> {
   const config = readSyncServerConfig()
   const host = config.lanEnabled ? '0.0.0.0' : '127.0.0.1'
   const lanIp = config.lanEnabled ? getLocalNetworkIp() : undefined
-  const tls = config.httpsEnabled
-    ? await ensureSyncServerCert(lanIp)
-    : undefined
+  const tls = config.httpsEnabled ? ensureSyncServerCert(lanIp) : undefined
 
   return startSyncServer({
     storagePath: syncStoragePath(),

--- a/apps/web-client/src/main.tsx
+++ b/apps/web-client/src/main.tsx
@@ -4,9 +4,12 @@ import { App } from '@tapes-monorepo/core'
 import './index.css'
 import DownloadPrompt from './DownloadPrompt'
 
-if (!import.meta.env.VITE_SYNC_SERVER_URL) {
-  throw new Error('VITE_SYNC_SERVER_URL not set')
-}
+// When the bundle is served from the Electron host, the sync server lives on
+// the same origin, so derive the URL from window.location. A build-time
+// VITE_SYNC_SERVER_URL (the Vercel deploy path) still takes precedence.
+const syncServerUrl =
+  import.meta.env.VITE_SYNC_SERVER_URL ??
+  `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`
 
 if (!window.Worker) {
   ReactDOM.createRoot(document.getElementById('root')!).render(
@@ -33,7 +36,7 @@ if (!window.Worker) {
       <div className="flex sm:hidden">
         <App
           appContextValue={{ type: 'web-client', worker }}
-          syncServerUrl={import.meta.env.VITE_SYNC_SERVER_URL}
+          syncServerUrl={syncServerUrl}
         />
       </div>
       <div className="mx-auto hidden h-screen w-screen max-w-screen-sm flex-col items-center justify-center gap-16 sm:flex">

--- a/apps/web-client/src/vite-env.d.ts
+++ b/apps/web-client/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_SYNC_SERVER_URL: string
+  readonly VITE_SYNC_SERVER_URL?: string
 }
 
 interface ImportMeta {

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -20,6 +20,7 @@ export type ValidIpcChanel =
   | 'recorder:stop'
   | 'sync:get-server-info'
   | 'sync:set-lan-enabled'
+  | 'sync:set-https-enabled'
 
 export type SyncServerInfo = {
   running: boolean
@@ -99,6 +100,7 @@ type IpcSendArgs =
   | ['recorder:stop', IpcRequest]
   | ['sync:get-server-info']
   | ['sync:set-lan-enabled', IpcRequest & { data: { enabled: boolean } }]
+  | ['sync:set-https-enabled', IpcRequest & { data: { enabled: boolean } }]
 export class IpcService {
   private ipcRenderer?: Window['api']
 

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -25,6 +25,10 @@ export type SyncServerInfo = {
   running: boolean
   url: string
   lanUrl?: string
+  /** URL of the hosted web-client bundle, when one is being served. */
+  webAppUrl?: string
+  /** LAN-reachable URL of the hosted web-client bundle. */
+  lanWebAppUrl?: string
   port: number
   host: string
 }

--- a/packages/core/app/context/SettingsContext.tsx
+++ b/packages/core/app/context/SettingsContext.tsx
@@ -9,6 +9,7 @@ type Settings = {
   syncServerMode: 'embedded' | 'remote' | undefined
   remoteSyncServerUrl: string | undefined
   syncServerLanEnabled: 'true' | 'false' | undefined
+  syncServerHttpsEnabled: 'true' | 'false' | undefined
 }
 
 const SettingsContext = createContext<{

--- a/packages/core/app/views/Settings.tsx
+++ b/packages/core/app/views/Settings.tsx
@@ -21,11 +21,27 @@ export function Settings() {
   const [storageLocation, setStorageLocation] = useSetting('storageLocation')
   const { automergeUrl, setAutomergeUrl } = useAutomergeUrl()
   const [importUrl, setImportUrl] = useState('')
+  const [syncServerLanEnabled] = useSetting('syncServerLanEnabled')
+  const [hostedBaseUrl, setHostedBaseUrl] = useState<string | null>(null)
+
+  // On the desktop app, guests should load the web-client from this host
+  // (same origin as the sync server) rather than the deployed Vercel build,
+  // so they don't hit HTTPS-vs-ws mixed-content. Only the LAN-reachable URL
+  // works for another device; without it we fall back to the hosted build.
+  useEffect(() => {
+    if (appContext.type !== 'electron-client') {
+      return
+    }
+    appContext.ipc
+      .send<SyncServerInfo>('sync:get-server-info')
+      .then((info) => setHostedBaseUrl(info.lanWebAppUrl ?? null))
+  }, [appContext, syncServerLanEnabled])
 
   const baseUrl =
-    process.env.NODE_ENV === 'development'
+    hostedBaseUrl ??
+    (process.env.NODE_ENV === 'development'
       ? `${import.meta.env.VITE_LOCAL_NETWORK_PROTOCOL}://${import.meta.env.VITE_LOCAL_NETWORK_IP}:3000`
-      : 'https://tapes-monorepo-web-client.vercel.app'
+      : 'https://tapes-monorepo-web-client.vercel.app')
 
   return (
     <div className="flex flex-col gap-4">
@@ -299,21 +315,26 @@ function SyncSettings() {
             Share with other devices on this network
           </label>
           <p className="pl-2 text-xs text-zinc-500">
-            Anyone on your local network can connect to the sync server while
-            this is enabled. Devices served over HTTPS (like the hosted web
-            client) cannot connect to a local ws:// address.
+            Anyone on your local network can connect while this is enabled. Open
+            the app URL below on another device to browse, play back, and sync
+            recordings — no install needed. Recording from a guest device
+            requires a secure (HTTPS) connection and isn&apos;t available yet
+            over plain http.
           </p>
-          {syncServerLanEnabled === 'true' && serverInfo?.lanUrl && (
+          {syncServerLanEnabled === 'true' && serverInfo?.lanWebAppUrl && (
             <div className="flex items-center gap-2 pl-2">
-              <p className="truncate text-xs" title={serverInfo.lanUrl}>
-                {serverInfo.lanUrl}
+              <p
+                className="truncate text-xs"
+                title={serverInfo.lanWebAppUrl}
+              >
+                {serverInfo.lanWebAppUrl}
               </p>
               <Button
                 className="w-fit rounded-full p-2"
-                title="Copy sync server URL to clipboard"
+                title="Copy web app URL to clipboard"
                 onClick={() => {
-                  if (serverInfo.lanUrl) {
-                    navigator.clipboard.writeText(serverInfo.lanUrl)
+                  if (serverInfo.lanWebAppUrl) {
+                    navigator.clipboard.writeText(serverInfo.lanWebAppUrl)
                   }
                 }}
               >

--- a/packages/core/app/views/Settings.tsx
+++ b/packages/core/app/views/Settings.tsx
@@ -316,10 +316,10 @@ function SyncSettings() {
           </label>
           <p className="pl-2 text-xs text-zinc-500">
             Anyone on your local network can connect while this is enabled. Open
-            the app URL below on another device to browse, play back, and sync
-            recordings — no install needed. Recording from a guest device
-            requires a secure (HTTPS) connection and isn&apos;t available yet
-            over plain http.
+            the app URL below on another device to browse the synced recording
+            library — no install needed. Playing back and recording audio on a
+            guest device both require a secure (HTTPS) connection, which
+            isn&apos;t available yet over plain http.
           </p>
           {syncServerLanEnabled === 'true' && serverInfo?.lanWebAppUrl && (
             <div className="flex items-center gap-2 pl-2">

--- a/packages/core/app/views/Settings.tsx
+++ b/packages/core/app/views/Settings.tsx
@@ -208,6 +208,9 @@ function SyncSettings() {
   const [syncServerLanEnabled, setSyncServerLanEnabled] = useSetting(
     'syncServerLanEnabled',
   )
+  const [syncServerHttpsEnabled, setSyncServerHttpsEnabled] = useSetting(
+    'syncServerHttpsEnabled',
+  )
   const [remoteUrlDraft, setRemoteUrlDraft] = useState(
     remoteSyncServerUrl ?? '',
   )
@@ -317,10 +320,44 @@ function SyncSettings() {
           <p className="pl-2 text-xs text-zinc-500">
             Anyone on your local network can connect while this is enabled. Open
             the app URL below on another device to browse the synced recording
-            library — no install needed. Playing back and recording audio on a
-            guest device both require a secure (HTTPS) connection, which
-            isn&apos;t available yet over plain http.
+            library — no install needed.
           </p>
+          {syncServerLanEnabled === 'true' && (
+            <>
+              <label className="flex items-center gap-2 pl-2">
+                <input
+                  type="checkbox"
+                  checked={syncServerHttpsEnabled === 'true'}
+                  onChange={async (event) => {
+                    const enabled = event.target.checked
+                    const info = (await appContext.ipc.send<
+                      SyncServerInfo | undefined
+                    >('sync:set-https-enabled', {
+                      data: { enabled },
+                    })) as SyncServerInfo | undefined
+
+                    if (!info) {
+                      console.error('No response from sync:set-https-enabled')
+                      return
+                    }
+
+                    setSyncServerHttpsEnabled(enabled ? 'true' : 'false')
+                    setServerInfo(info)
+                    // The server's scheme (ws/wss) changed, so this device's
+                    // own connection URL is now stale — reconnect on reload.
+                    window.location.reload()
+                  }}
+                />
+                Use HTTPS (lets guests play back and record)
+              </label>
+              <p className="pl-2 text-xs text-zinc-500">
+                Guests need a secure connection to play back or record audio.
+                With HTTPS on, a guest accepts a one-time certificate warning
+                (the certificate is self-signed by this device), then gets full
+                functionality. Without it, guests can only browse the library.
+              </p>
+            </>
+          )}
           {syncServerLanEnabled === 'true' && serverInfo?.lanWebAppUrl && (
             <div className="flex items-center gap-2 pl-2">
               <p

--- a/yarn.lock
+++ b/yarn.lock
@@ -5156,6 +5156,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/node-forge@npm:^1.3.0":
+  version: 1.3.14
+  resolution: "@types/node-forge@npm:1.3.14"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10c0/da6158fd34fa7652aa7f8164508f97a76b558724ab292f13c257e39d54d95d4d77604e8fb14dc454a867f1aeec7af70118294889195ec4400cecbb8a5c77a212
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*, @types/node@npm:>=10.0.0":
   version: 26.1.1
   resolution: "@types/node@npm:26.1.1"
@@ -5228,6 +5237,15 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/a58ba341cb9e7d74f71810a88862da7b2a6fa42e2a1fc0ce40498f6ea1d44382f0640117057da779f74c47039f7166bf48fad02dc876f94e005c7afa50f5e129
+  languageName: node
+  linkType: hard
+
+"@types/selfsigned@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@types/selfsigned@npm:2.1.0"
+  dependencies:
+    selfsigned: "npm:*"
+  checksum: 10c0/26d394f8ebba1a6651dcb437a50158d4f098ef918ee8e3d2494030ac0c3e1641282ce67002f3e359113b6e673c74ddd0612c2f509a05d0d1b348ab521c853c79
   languageName: node
   linkType: hard
 
@@ -8180,6 +8198,7 @@ __metadata:
     "@types/node": "npm:^24.0.0"
     "@types/react": "npm:^19.0.1"
     "@types/react-dom": "npm:^19.0.1"
+    "@types/selfsigned": "npm:^2.1.0"
     "@types/ws": "npm:^8.5.13"
     "@typescript-eslint/eslint-plugin": "npm:^8.0.0"
     "@typescript-eslint/parser": "npm:^8.0.0"
@@ -8196,7 +8215,7 @@ __metadata:
     prettier-plugin-tailwindcss: "npm:^0.8.1"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    selfsigned: "npm:^5.5.0"
+    selfsigned: "npm:^2.4.1"
     tailwindcss: "npm:^4.3.3"
     ts-node: "npm:^10.9.2"
     typescript: "npm:~6.0.0"
@@ -12634,6 +12653,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-forge@npm:^1":
+  version: 1.4.0
+  resolution: "node-forge@npm:1.4.0"
+  checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1
+  languageName: node
+  linkType: hard
+
 "node-gyp-build-optional-packages@npm:5.1.1":
   version: 5.1.1
   resolution: "node-gyp-build-optional-packages@npm:5.1.1"
@@ -14577,13 +14603,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selfsigned@npm:^5.5.0":
+"selfsigned@npm:*":
   version: 5.5.0
   resolution: "selfsigned@npm:5.5.0"
   dependencies:
     "@peculiar/x509": "npm:^1.14.2"
     pkijs: "npm:^3.3.3"
   checksum: 10c0/a31e9d928e22cd6f4e14759a099feba79d9d789c852c7cf65ff8e2f62d7f6313fe477639590e7ed06115b4516a4bebbe0dec5d072a2d01cc372a9cfd58eb893b
+  languageName: node
+  linkType: hard
+
+"selfsigned@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "selfsigned@npm:2.4.1"
+  dependencies:
+    "@types/node-forge": "npm:^1.3.0"
+    node-forge: "npm:^1"
+  checksum: 10c0/521829ec36ea042f7e9963bf1da2ed040a815cf774422544b112ec53b7edc0bc50a0f8cc2ae7aa6cc19afa967c641fd96a15de0fc650c68651e41277d2e1df09
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3174,6 +3174,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@noble/hashes@npm:1.4.0"
+  checksum: 10c0/8c3f005ee72e7b8f9cff756dfae1241485187254e3f743873e22073d63906863df5d4f13d441b7530ea614b7a093f0d889309f28b59850f33b66cb26a779a4a5
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:^1.1.5, @noble/hashes@npm:^1.2.0":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
@@ -3717,6 +3724,160 @@ __metadata:
   dependencies:
     "@noble/hashes": "npm:^1.1.5"
   checksum: 10c0/6576b73de49d826b0f33cbab88424dec1f6fa454a9e59a7b621f78c2cfdd2e59d7f48175826d698940a717f45eeb5e87a508583a7316e608f6a05a861a40c129
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-cms@npm:^2.6.0, @peculiar/asn1-cms@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-cms@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    "@peculiar/asn1-x509-attr": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/001601e4b7a4acd3f50ab0dfaf0bb781b540df3744ed3a344cb3164c0c9f1146d54db8a96b21423769f494644f7ff4444e8c0276a40df900c3c5cdc5d849b942
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-csr@npm:^2.6.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-csr@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/0ac7cc417b3b4dc80adf60c0650daec329dd04dd971813b89910e6984279030ccc1a2014125388612d7f3895a614938fa66d5547fda3e62e094e11cf1a3b80d9
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-ecc@npm:^2.6.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-ecc@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/38a026c07837b69ea665a37bb129c47109193b48bd5840c088a023c4cdb953ac3c2a7eb930c5472476662bf87018f2041fd00b58c17fe235d43ecdf1efb07649
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-pfx@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-pfx@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-cms": "npm:^2.8.0"
+    "@peculiar/asn1-pkcs8": "npm:^2.8.0"
+    "@peculiar/asn1-rsa": "npm:^2.8.0"
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/8bdc99ffba97b2cced084e2456f9475207d00a5a9a7558ad79824545551628efee7e722f74a5ff00af2cc5bbfa8a0a0413cb1672e83ad13d0243ed550c04da12
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-pkcs8@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-pkcs8@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/1231f7e1e0573be6cd2a012a74b736e884e0221535eca49d1530fa53be05e3542b81871a0cf99756ca24a7bc224f21e7c1b5911851850ed2b0ac0e95a179cb11
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-pkcs9@npm:^2.6.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-pkcs9@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-cms": "npm:^2.8.0"
+    "@peculiar/asn1-pfx": "npm:^2.8.0"
+    "@peculiar/asn1-pkcs8": "npm:^2.8.0"
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    "@peculiar/asn1-x509-attr": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/a5127573e0fcc99ce12f1b1f418e54e77186d28fb47160e1bf86458afcf87df048117f8b917af0db78229f739d9bbb74a16294129af538600d4c8cf1cb20435d
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-rsa@npm:^2.6.0, @peculiar/asn1-rsa@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-rsa@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/877e6a228a629011af54d02366fd22de10578468f59e13142eccbe78cce3436d4172398debf2023256145fb39cb9f725c9c2198c8c14a8b03b37319ab36889eb
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-schema@npm:^2.6.0, @peculiar/asn1-schema@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-schema@npm:2.8.0"
+  dependencies:
+    "@peculiar/utils": "npm:^2.0.2"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/dae27e5501784daa2401478cc2ee2c915698ef12415df1a5af249fb60dff0b363ecdccbae6f04b8e121649a187192510475d86fc15c582718299440164f0570e
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-x509-attr@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-x509-attr@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/asn1-x509": "npm:^2.8.0"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/e819d16c0d236abb8367c150880deec7052a06134f4077c10c57287cb1c3aa0d06b421b0e58f52a152c2440e20e03de7e2491738cc35745fb9d8b2e6c59a4a01
+  languageName: node
+  linkType: hard
+
+"@peculiar/asn1-x509@npm:^2.6.0, @peculiar/asn1-x509@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@peculiar/asn1-x509@npm:2.8.0"
+  dependencies:
+    "@peculiar/asn1-schema": "npm:^2.8.0"
+    "@peculiar/utils": "npm:^2.0.2"
+    asn1js: "npm:^3.0.10"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/3aa58f110d0b44492cdb91dcc57436b6b46d2df67f1ba952b56b43e19d98c2ba17be3173a7561ec463ded26e9f6985ee612b7b59d049f89fd1a8ebacc1b25dca
+  languageName: node
+  linkType: hard
+
+"@peculiar/utils@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@peculiar/utils@npm:2.0.3"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/e111a51c83334d6ff3c96b993ed0d718210620f3ad176853a4bf229f1cf4cd14e9388075318351b188862d34d2192d80f206f6bea53aa1459df3ec638cbcdbd5
+  languageName: node
+  linkType: hard
+
+"@peculiar/x509@npm:^1.14.2":
+  version: 1.14.3
+  resolution: "@peculiar/x509@npm:1.14.3"
+  dependencies:
+    "@peculiar/asn1-cms": "npm:^2.6.0"
+    "@peculiar/asn1-csr": "npm:^2.6.0"
+    "@peculiar/asn1-ecc": "npm:^2.6.0"
+    "@peculiar/asn1-pkcs9": "npm:^2.6.0"
+    "@peculiar/asn1-rsa": "npm:^2.6.0"
+    "@peculiar/asn1-schema": "npm:^2.6.0"
+    "@peculiar/asn1-x509": "npm:^2.6.0"
+    pvtsutils: "npm:^1.3.6"
+    reflect-metadata: "npm:^0.2.2"
+    tslib: "npm:^2.8.1"
+    tsyringe: "npm:^4.10.0"
+  checksum: 10c0/949231ca9daf84534bfe255f28a856df497302fed294d227c6a28e50f5cfb67ed1d91afe6db787b88294ce042295243dbcb44455fe2efa5ed07428a74392eec9
   languageName: node
   linkType: hard
 
@@ -6642,6 +6803,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asn1js@npm:^3.0.10, asn1js@npm:^3.0.6":
+  version: 3.0.10
+  resolution: "asn1js@npm:3.0.10"
+  dependencies:
+    pvtsutils: "npm:^1.3.6"
+    pvutils: "npm:^1.1.5"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/04056106522e4d0db4eb992299bb76d73438bfd59ffd975ac9c1f15d14e7326161dad383c54a5ccfa203b73ae7b7bf4668f42c2fed01e1f4bf79a58de71e4dc6
+  languageName: node
+  linkType: hard
+
 "assertion-error@npm:^2.0.1":
   version: 2.0.1
   resolution: "assertion-error@npm:2.0.1"
@@ -7029,6 +7201,13 @@ __metadata:
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
+  languageName: node
+  linkType: hard
+
+"bytestreamjs@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "bytestreamjs@npm:2.0.1"
+  checksum: 10c0/edd66b7ca3f94aae99a1009304a42d82ca4c2085eb934192ff47a81f59215c975dc9d3cd8f23c40a2f43ef5b2fa6f01ace70b10ad247766cec6ec641b89eab48
   languageName: node
   linkType: hard
 
@@ -8017,6 +8196,7 @@ __metadata:
     prettier-plugin-tailwindcss: "npm:^0.8.1"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
+    selfsigned: "npm:^5.5.0"
     tailwindcss: "npm:^4.3.3"
     ts-node: "npm:^10.9.2"
     typescript: "npm:~6.0.0"
@@ -13327,6 +13507,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pkijs@npm:^3.3.3":
+  version: 3.4.0
+  resolution: "pkijs@npm:3.4.0"
+  dependencies:
+    "@noble/hashes": "npm:1.4.0"
+    asn1js: "npm:^3.0.6"
+    bytestreamjs: "npm:^2.0.1"
+    pvtsutils: "npm:^1.3.6"
+    pvutils: "npm:^1.1.3"
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/33cfab9283702782ae228bd2d4a51b1e9b2e0d6e2141207f29ee95716101ac4fe6e6821882da5f5eca28c74be3964b181b09e95cbbb757b2bd9dca918a5765fd
+  languageName: node
+  linkType: hard
+
 "playwright-core@npm:1.61.1":
   version: 1.61.1
   resolution: "playwright-core@npm:1.61.1"
@@ -13621,6 +13815,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pvtsutils@npm:^1.3.6":
+  version: 1.3.6
+  resolution: "pvtsutils@npm:1.3.6"
+  dependencies:
+    tslib: "npm:^2.8.1"
+  checksum: 10c0/b1b42646370505ccae536dcffa662303b2c553995211330c8e39dec9ab8c197585d7751c2c5b9ab2f186feda0219d9bb23c34ee1e565573be96450f79d89a13c
+  languageName: node
+  linkType: hard
+
+"pvutils@npm:^1.1.3, pvutils@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "pvutils@npm:1.1.5"
+  checksum: 10c0/e968b07b78a58fec9377fe7aa6342c8cfa21c8fb4afc4e51e1489bd42bec6dc71b8a52541d0aede0aea17adec7ca3f89f29f56efdc31d0083cc02e9bb5721bcf
+  languageName: node
+  linkType: hard
+
 "qrcode.react@npm:^4.2.0":
   version: 4.2.0
   resolution: "qrcode.react@npm:4.2.0"
@@ -13840,7 +14050,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reflect-metadata@npm:^0.2.0":
+"reflect-metadata@npm:^0.2.0, reflect-metadata@npm:^0.2.2":
   version: 0.2.2
   resolution: "reflect-metadata@npm:0.2.2"
   checksum: 10c0/1cd93a15ea291e420204955544637c264c216e7aac527470e393d54b4bb075f10a17e60d8168ec96600c7e0b9fcc0cb0bb6e91c3fbf5b0d8c9056f04e6ac1ec2
@@ -14364,6 +14574,16 @@ __metadata:
     ajv-formats: "npm:^2.1.1"
     ajv-keywords: "npm:^5.1.0"
   checksum: 10c0/1c8d2c480a026d7c02ab2ecbe5919133a096d6a721a3f201fa50663e4f30f6d6ba020dfddd93cb828b66b922e76b342e103edd19a62c95c8f60e9079cc403202
+  languageName: node
+  linkType: hard
+
+"selfsigned@npm:^5.5.0":
+  version: 5.5.0
+  resolution: "selfsigned@npm:5.5.0"
+  dependencies:
+    "@peculiar/x509": "npm:^1.14.2"
+    pkijs: "npm:^3.3.3"
+  checksum: 10c0/a31e9d928e22cd6f4e14759a099feba79d9d789c852c7cf65ff8e2f62d7f6313fe477639590e7ed06115b4516a4bebbe0dec5d072a2d01cc372a9cfd58eb893b
   languageName: node
   linkType: hard
 
@@ -15642,6 +15862,22 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^1.9.3":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: 10c0/69ae09c49eea644bc5ebe1bca4fa4cc2c82b7b3e02f43b84bd891504edf66dbc6b2ec0eef31a957042de2269139e4acff911e6d186a258fb14069cd7f6febce2
+  languageName: node
+  linkType: hard
+
+"tsyringe@npm:^4.10.0":
+  version: 4.10.0
+  resolution: "tsyringe@npm:4.10.0"
+  dependencies:
+    tslib: "npm:^1.9.3"
+  checksum: 10c0/918594b4dfac97beb8be2c041c6ec45f078ef3768ed4edfe35ae2c709ab503e2e6b454b2b37e692c658572d1972a428fbfdbc0a2b42fee727a83c1c685fbe5e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Serves the built `apps/web-client` bundle from the Electron host over the **same origin** as the embedded Automerge sync server (#250), so a guest device on the LAN loads the app and opens its sync socket against one host:port. This collapses the mixed-content problem that blocked the deployed HTTPS web-client from reaching a `ws://` LAN sync server, and (over HTTPS) gives the guest a secure context. Tracked in Linear: TAP-56.

> **Stacked on #250.** Base is `claude/tapes-api-electron-client-9cbzbt` (the TAP-55 embedded-sync-server branch), so this PR shows only the diff for this work. Retarget to `main` once #250 merges.

## Two phases, both included here

**Phase A — plain HTTP serving (foundation).** The sync server's existing `http.Server` (which already carries the `ws` upgrade) also serves the web-client bundle as static files. Over plain http a guest can **browse the synced library**; playback and recording don't work yet (secure-context APIs — see below).

**Phase B — self-signed HTTPS on one port (the real guest experience).** Optionally serve the LAN over HTTPS so a guest gets a **secure context**, which both recording *and playback* require, and the `wss://` sync handshake reuses the accepted cert exception because it's the same origin.

### Why HTTPS is needed for playback too (corrects an earlier assumption)

Playback in the web-client reads recording bytes from **OPFS** (`worker.ts` `navigator.storage.getDirectory()`, via the player's `storage:get`), which is secure-context-only exactly like `getUserMedia`. So plain http gives a guest browse-only; HTTPS unlocks playback and recording. (The `<audio>`/blob-URL machinery is fine on http — OPFS is the sole blocker; no Service Worker or `crypto.subtle` adds further gates.)

Separately, the synced Automerge doc carries **metadata only** — audio bytes live in the recorder's OPFS and never enter the doc — so a guest can't play a **host's** recording even over HTTPS. That cross-device byte-transfer gap is out of scope here and tracked in **TAP-57**.

## What changed

**Serving / wiring (Phase A)**
- **`src/syncServer.ts`** — the `http.Server` now serves the web-client bundle as static files: SPA fallback to `index.html` (so `/?am=<automergeUrl>` deep links work), a broad static MIME map, and path-traversal protection. `SyncServerInfo` gains `webAppUrl` / `lanWebAppUrl`.
- **`apps/web-client/src/main.tsx`** (+ `vite-env.d.ts`) — derives `syncServerUrl` from `window.location` (`ws`/`wss` by page protocol) when `VITE_SYNC_SERVER_URL` is unset; the Vercel deploy path still wins.
- **`src/syncServerConfig.ts`** — `webClientPath()` resolves the bundle dir (extraResource in prod, sibling `dist` in dev), `undefined` when absent.
- **Build/packaging** — `forge.config.ts` adds the staged `web-client` dir to `extraResource`; a `stage-web-client` script builds + copies the bundle before `package`/`make`/`publish`.
- **`packages/core/app/views/Settings.tsx`** — desktop replicate-data QR/copy-link points at the host's LAN web-app URL over the existing `sync:get-server-info` IPC.
- **`packages/core/app/IpcService.ts`** — mirrors the new `SyncServerInfo` fields.

**HTTPS (Phase B)**
- **`src/certManager.ts`** (new) — generates a self-signed cert at runtime via `selfsigned` (pure JS, no `openssl`), with the **LAN IP in the subjectAltName** so `https://<lan-ip>` validates. Persisted under `userData/sync-tls`, regenerated when the LAN IP changes so a guest's accepted exception survives restarts.
- **`src/syncServer.ts`** — when TLS material is supplied, runs `https.createServer` instead of `http`; the attached `ws` server upgrades to `wss` transparently. URLs switch to `https`/`wss`.
- **`src/syncServerRuntime.ts`** (new) — single place composing the persisted config (LAN + HTTPS flags) into server options and (re)starting the server; shared by app bootstrap and both IPC toggles.
- **`src/main.ts`** — trusts exactly our own cert (by PEM match) in the `certificate-error` handler so the host's own renderer can connect over `wss://127.0.0.1` without weakening verification for anything else.
- **New `sync:set-https-enabled` IPC channel** (registered, allowlisted, typed) + `httpsEnabled` config flag; **`Settings.tsx`** gets a "Use HTTPS" toggle under the LAN option (reloads so this device reconnects on the new scheme) with copy explaining the one-time certificate warning.

## Verification

- `@tapes-monorepo/core` build, type-checks, and lint pass for `core`, `electron-client`, and `web-client`.
- `web-client` builds with `VITE_SYNC_SERVER_URL` unset; assets use `base: '/'` so they serve from the origin root.
- Static handler exercised end-to-end: `/`, `/index.html`, `/assets/*.js` (correct MIME), `/?am=...` and unknown SPA routes → index fallback; `..` and `%2e%2e` traversal fall back to index without leaking files above the root.
- TLS path exercised end-to-end: `selfsigned` mints a cert with the LAN IP in the SAN, and one `https` port serves both the static bundle and the `wss` upgrade over TLS.

## Not yet verified (needs a packaged app + a second LAN device)

- Packaged-app run (`yarn workspace electron-client package`) and the bundled `extraResource` path.
- Guest library browse/sync over http; and over HTTPS: the browser cert interstitial, secure-context **recording and playback of the guest's own recordings**, and cert-covers-`wss` behavior across target browsers (Chromium + Safari/iOS).
- Playing back a **host's** recording on a guest is out of scope here — see **TAP-57**.

## Follow-up

- **TAP-57** — sync the audio bytes cross-device (metadata-only doc today), so a guest can play a host's recording. Independent of TLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)