### PR TITLE
feat(electron-client): HMR for the LAN guest client (TAP-60)

### DIFF
--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -7,7 +7,8 @@
   "repository": "github:phonofidelic/tapes-monorepo",
   "scripts": {
     "get-bin": "tsc downloadExecutables.ts && node downloadExecutables.js",
-    "dev": "LOCAL_NETWORK_IP=\"$(ipconfig getifaddr en0)\" dotenvx run --env-file=.env.local -- electron-forge start -- --trace-warnings",
+    "dev": "LOCAL_NETWORK_IP=\"$(ipconfig getifaddr en0)\" WEB_CLIENT_DEV_URL=\"http://$(ipconfig getifaddr en0):3000\" dotenvx run --env-file=.env.local -- electron-forge start -- --trace-warnings",
+    "dev:https": "LOCAL_NETWORK_IP=\"$(ipconfig getifaddr en0)\" WEB_CLIENT_DEV_URL=\"https://$(ipconfig getifaddr en0):3000\" dotenvx run --env-file=.env.local -- electron-forge start -- --trace-warnings",
     "stage-web-client": "yarn workspace web-client build && find web-client -mindepth 1 ! -name .gitkeep -delete && cp -R ../web-client/dist/. web-client/",
     "package": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge package",
     "make": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge make",

--- a/apps/electron-client/src/syncServer.ts
+++ b/apps/electron-client/src/syncServer.ts
@@ -47,6 +47,13 @@ export type SyncServerOptions = {
    * `wss://` handshake reuses the accepted cert exception (same origin).
    */
   tls?: { key: string; cert: string }
+  /**
+   * In development, the LAN URL of the web-client's Vite dev server. When set it
+   * is advertised to guests (as `webAppUrl`/`lanWebAppUrl`) instead of a URL for
+   * the statically served bundle, so guests load the HMR-enabled dev server. The
+   * sync socket still runs here; the dev server proxies `/sync` back to it.
+   */
+  webAppDevUrl?: string
 }
 
 type RunningSyncServer = {
@@ -189,7 +196,8 @@ export async function startSyncServer(
     await initializeBase64Wasm(automergeWasmBase64)
   }
 
-  const { storagePath, host, peerId, webClientPath, tls } = options
+  const { storagePath, host, peerId, webClientPath, tls, webAppDevUrl } =
+    options
   const requestedPort = options.port ?? DEFAULT_SYNC_SERVER_PORT
 
   const handler = createRequestHandler(webClientPath)
@@ -233,9 +241,14 @@ export async function startSyncServer(
       running: true,
       url: `${wsScheme}://127.0.0.1:${port}`,
       lanUrl: lanIp ? `${wsScheme}://${lanIp}:${port}` : undefined,
-      webAppUrl: webClientPath ? `${httpScheme}://127.0.0.1:${port}` : undefined,
+      webAppUrl:
+        webAppDevUrl ??
+        (webClientPath ? `${httpScheme}://127.0.0.1:${port}` : undefined),
       lanWebAppUrl:
-        webClientPath && lanIp ? `${httpScheme}://${lanIp}:${port}` : undefined,
+        webAppDevUrl ??
+        (webClientPath && lanIp
+          ? `${httpScheme}://${lanIp}:${port}`
+          : undefined),
       port,
       host,
     },

--- a/apps/electron-client/src/syncServerConfig.ts
+++ b/apps/electron-client/src/syncServerConfig.ts
@@ -32,6 +32,18 @@ export const webClientPath = (): string | undefined => {
   return existsSync(path.join(candidate, 'index.html')) ? candidate : undefined
 }
 
+/**
+ * In development the web-client is served by its own Vite dev server (for HMR),
+ * not the statically staged bundle. The dev scripts pass its LAN URL via
+ * `WEB_CLIENT_DEV_URL`; when present we advertise it to guests (see the QR/copy
+ * flow in core's Settings) so they load the HMR-enabled app instead of a stale
+ * static build. Returns `undefined` outside development.
+ */
+export const webClientDevUrl = (): string | undefined =>
+  process.env.NODE_ENV === 'development'
+    ? process.env.WEB_CLIENT_DEV_URL
+    : undefined
+
 export function readSyncServerConfig(): SyncServerConfig {
   try {
     const stored = JSON.parse(

--- a/apps/electron-client/src/syncServerRuntime.ts
+++ b/apps/electron-client/src/syncServerRuntime.ts
@@ -7,6 +7,7 @@ import {
 import {
   readSyncServerConfig,
   syncStoragePath,
+  webClientDevUrl,
   webClientPath,
 } from './syncServerConfig'
 import { ensureSyncServerCert } from './certManager'
@@ -28,6 +29,7 @@ export async function startSyncServerFromConfig(): Promise<SyncServerInfo> {
     host,
     peerId: config.peerId,
     webClientPath: webClientPath(),
+    webAppDevUrl: webClientDevUrl(),
     tls,
   })
 }

--- a/apps/web-client/src/main.tsx
+++ b/apps/web-client/src/main.tsx
@@ -5,11 +5,19 @@ import './index.css'
 import DownloadPrompt from './DownloadPrompt'
 
 // When the bundle is served from the Electron host, the sync server lives on
-// the same origin, so derive the URL from window.location. A build-time
-// VITE_SYNC_SERVER_URL (the Vercel deploy path) still takes precedence.
+// the same origin, so derive the URL from window.location. In development the
+// bundle is instead served by this package's own Vite dev server (for HMR), and
+// the sync socket reaches the host's embedded sync server through the `/sync`
+// proxy (see vite.config.ts). A build-time VITE_SYNC_SERVER_URL (the Vercel
+// deploy path) still takes precedence.
+const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
+// `import.meta.env.DEV` is a Vite build-time boolean (dev server vs. static
+// build), not a process env var; the disable is for turbo's env-var lint rule.
+// eslint-disable-next-line turbo/no-undeclared-env-vars
+const servedByDevServer = import.meta.env.DEV
 const syncServerUrl =
   import.meta.env.VITE_SYNC_SERVER_URL ??
-  `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`
+  `${scheme}://${window.location.host}${servedByDevServer ? '/sync' : ''}`
 
 if (!window.Worker) {
   ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/apps/web-client/vite.config.ts
+++ b/apps/web-client/vite.config.ts
@@ -29,6 +29,21 @@ export default defineConfig({
     },
   },
   plugins,
+  server: {
+    // When a LAN guest is served the app from this dev server (for HMR), its
+    // Automerge sync socket connects to `/sync` on the same origin. Proxy that
+    // to the Electron host's embedded sync server, which runs on loopback of
+    // this same machine (DEFAULT_SYNC_SERVER_PORT = 9001). `secure: false` lets
+    // a `wss://` guest (dev:https) tunnel to the plain `ws://` loopback target.
+    proxy: {
+      '/sync': {
+        target: 'ws://127.0.0.1:9001',
+        ws: true,
+        secure: false,
+        changeOrigin: true,
+      },
+    },
+  },
   build: {
     target: 'esnext',
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",
-    "dev:https": "turbo run @tapes-monorepo/ui#dev @tapes-monorepo/core#dev:https electron-client#dev web-client#dev:https api#dev",
+    "dev:https": "turbo run @tapes-monorepo/ui#dev @tapes-monorepo/core#dev:https electron-client#dev:https web-client#dev:https api#dev",
     "lint": "turbo lint",
     "check-types": "turbo check-types",
     "test": "turbo test",

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "globalEnv": ["NODE_ENV"],
+  "globalEnv": ["NODE_ENV", "WEB_CLIENT_DEV_URL"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Context

Closes TAP-60. Builds on the LAN guest-hosting work (Phase A/B), now on `main`.

In development, LAN guests were served the *statically staged* `web-client/dist` bundle over the embedded sync server (port 9001). That has no HMR and is stale unless manually rebuilt (or absent entirely during `yarn dev`).

## Change

Point guests at the web-client's own Vite dev server (native HMR) and proxy its sync WebSocket back to the embedded sync server, keeping Vite as the single guest origin (one cert exception via `basicSsl`):

- **`apps/web-client/vite.config.ts`** — `server.proxy` routes `/sync` (ws) → `ws://127.0.0.1:9001` (the embedded sync server on loopback).
- **`apps/web-client/src/main.tsx`** — when served by the Vite dev server (`import.meta.env.DEV`), the sync URL targets the proxied `/sync` path. Static/Vercel builds are unchanged.
- **`apps/electron-client/src/syncServer{,Config,Runtime}.ts`** — a dev-only `webAppDevUrl` (from `WEB_CLIENT_DEV_URL`) is advertised as `webAppUrl`/`lanWebAppUrl`, so the existing Settings copy/QR flow sends guests to the HMR server.
- **`apps/electron-client/package.json`** — `dev`/new `dev:https` scripts export `WEB_CLIENT_DEV_URL` (`http`/`https`://`<lan-ip>`:3000); root `dev:https` now runs `electron-client#dev:https`; `turbo.json` declares the env var.

Production is untouched — it still serves the static staged bundle.

## Verification

- ✅ `yarn turbo lint check-types --filter=web-client --filter=electron-client` — 8/8, no warnings.
- ⏳ Manual (needs a LAN device): `yarn dev:https` → enable "Share with other devices" in Settings → confirm URL is `https://<lan-ip>:3000` → open on a device → confirm sync works → edit a source string → confirm HMR updates the guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)