### PR TITLE
fix(electron-client): guest sync hangs on 'Loading...' in HMR dev flow

### DIFF
--- a/apps/electron-client/src/syncServerRuntime.ts
+++ b/apps/electron-client/src/syncServerRuntime.ts
@@ -22,14 +22,23 @@ export async function startSyncServerFromConfig(): Promise<SyncServerInfo> {
   const config = readSyncServerConfig()
   const host = config.lanEnabled ? '0.0.0.0' : '127.0.0.1'
   const lanIp = config.lanEnabled ? getLocalNetworkIp() : undefined
-  const tls = config.httpsEnabled ? ensureSyncServerCert(lanIp) : undefined
+
+  // In the HMR dev flow, guests don't hit the sync socket directly: they load
+  // the web-client's Vite dev server and reach the socket through its `/sync`
+  // proxy over loopback. Both the loopback hop and the dev server (basic-ssl)
+  // are already secure contexts, so the embedded server needs no TLS of its own
+  // — and running it plain keeps that proxy's `ws://` target valid. TLS is only
+  // for the production flow, where guests connect to this origin directly.
+  const devWebAppUrl = webClientDevUrl()
+  const tls =
+    config.httpsEnabled && !devWebAppUrl ? ensureSyncServerCert(lanIp) : undefined
 
   return startSyncServer({
     storagePath: syncStoragePath(),
     host,
     peerId: config.peerId,
     webClientPath: webClientPath(),
-    webAppDevUrl: webClientDevUrl(),
+    webAppDevUrl: devWebAppUrl,
     tls,
   })
 }


### PR DESCRIPTION
## Problem

Follow-up to #253 (TAP-60). Opening the guest on another device (via the QR code) hangs on **"Loading..."** — `App.tsx` with no repo.

The guest *does* receive the host's doc URL (QR `?am=`), so it enters `await repo.find(url)` and waits for the doc to sync. It never arrives, so `find()` never resolves.

## Root cause

Confirmed empirically:

- The Vite `/sync` ws-proxy mechanism works when schemes match (plain-ws → plain-ws: connection opens, frames flow on path `/sync`; the Automerge server ignores the path).
- The failure is a **scheme mismatch**: with **"Use HTTPS"** enabled in Settings, the embedded sync server runs `wss://` (TLS) on 9001, but the proxy targets plain `ws://127.0.0.1:9001`. A plaintext connection to the TLS port is reset — `wss://127.0.0.1:9001/sync` opens, `ws://127.0.0.1:9001/sync` → *socket hang up*.

## Fix

In the HMR dev flow, guests never hit the sync socket directly — they load the web-client Vite dev server and reach the socket through its `/sync` proxy over **loopback**. Both the loopback hop and the dev server (basic-ssl) are already secure contexts, so the embedded server needs no TLS of its own here. Skip TLS when a dev web-app URL is being served, keeping the proxy's `ws://` target valid. The production flow (guests connect to this origin directly) still uses TLS.

Net effect: the Settings "Use HTTPS" toggle is a no-op in the dev flow — guests get their secure context from `yarn dev:https` (Vite basic-ssl), not from the embedded server.

## Verification

- ✅ `yarn turbo lint check-types --filter=electron-client --filter=web-client` — 8/8, no warnings.
- ⏳ Manual: `yarn dev:https`, share to a device via QR, confirm the library loads/syncs (no more "Loading...") and HMR updates the guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)