### PR TITLE
feat(core): sync recording audio bytes across devices (TAP-57)

### DIFF
--- a/apps/electron-client/index.html
+++ b/apps/electron-client/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; media-src http://localhost:* tapes:; style-src 'self'; script-src-elem 'self' 'wasm-unsafe-eval'; script-src 'wasm-unsafe-eval'; connect-src *" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; media-src http://localhost:* tapes: blob:; style-src 'self'; script-src-elem 'self' 'wasm-unsafe-eval'; script-src 'wasm-unsafe-eval'; connect-src *" />
     <title>Tapes</title>
     <script type="module" src="/src/renderer.tsx"></script>
   </head>

--- a/apps/electron-client/src/channels/ReadFileChannel.ts
+++ b/apps/electron-client/src/channels/ReadFileChannel.ts
@@ -1,0 +1,62 @@
+import path from 'path'
+import { readFile } from 'fs/promises'
+import { IpcMainEvent } from 'electron'
+import { IpcChannel, IpcRequest } from '@/types'
+
+// Maps recording file extensions to the MIME type playback needs to build a
+// correctly-typed Blob. Mirrors the map in cacheServer.ts.
+const mimeTypeByExtension: Record<string, string> = {
+  '.wav': 'audio/wav',
+  '.mp3': 'audio/mpeg',
+  '.ogg': 'audio/ogg',
+  '.flac': 'audio/flac',
+}
+
+export class ReadFileChannel implements IpcChannel {
+  name: string = 'storage:read-file'
+
+  async handle(event: IpcMainEvent, request: IpcRequest) {
+    const { data } = request
+    if (!request.responseChannel) {
+      throw new Error(`No response channel provided for ${this.name} request`)
+    }
+
+    if (!isValidReadFileRequestData(data)) {
+      throw new Error(`Invalid data provided for ${this.name} request`)
+    }
+
+    const { filepath } = data
+
+    try {
+      const buffer = await readFile(filepath)
+      // Hand Automerge a plain Uint8Array so it stores the bytes as a native
+      // binary column rather than serializing a Node Buffer object.
+      const bytes = new Uint8Array(buffer)
+      const mimeType =
+        mimeTypeByExtension[path.extname(filepath).toLowerCase()] ??
+        'application/octet-stream'
+      event.sender.send(request.responseChannel, {
+        success: true,
+        data: { bytes, mimeType },
+      })
+    } catch (error) {
+      console.error(error)
+      event.sender.send(request.responseChannel, {
+        success: false,
+        error,
+      })
+    }
+  }
+}
+
+const isValidReadFileRequestData = (
+  data: unknown,
+): data is { filepath: string } => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'filepath' in data &&
+    typeof data.filepath === 'string' &&
+    data.filepath.length > 0
+  )
+}

--- a/apps/electron-client/src/index.ts
+++ b/apps/electron-client/src/index.ts
@@ -3,6 +3,7 @@ import { DeleteRecordingChannel } from './channels/DeleteRecordingChannel'
 import { EditRecordingChannel } from './channels/EditRecordingChannel'
 import { GetSyncServerInfoChannel } from './channels/GetSyncServerInfoChannel'
 import { OpenDirectoryDialogChannel } from './channels/OpenDirectoryDialogChannel'
+import { ReadFileChannel } from './channels/ReadFileChannel'
 import { SetDefaultAudioInputChannel } from './channels/SetDefaultAudioInputChannel'
 import { SetSyncServerLanChannel } from './channels/SetSyncServerLanChannel'
 import { SetSyncServerHttpsChannel } from './channels/SetSyncServerHttpsChannel'
@@ -13,6 +14,7 @@ new MainWindow().init([
   new CreateRecordingChannel(),
   new EditRecordingChannel(),
   new DeleteRecordingChannel(),
+  new ReadFileChannel(),
   new SetDefaultAudioInputChannel(),
   new GetSyncServerInfoChannel(),
   new SetSyncServerLanChannel(),

--- a/apps/electron-client/src/preload.ts
+++ b/apps/electron-client/src/preload.ts
@@ -9,6 +9,7 @@ const validChannels: ValidIpcChanel[] = [
   'storage:open-directory-dialog',
   'storage:edit-recording',
   'storage:delete-recording',
+  'storage:read-file',
   'recorder:start',
   'recorder:stop',
   'sync:get-server-info',

--- a/apps/web-client/src/worker.ts
+++ b/apps/web-client/src/worker.ts
@@ -31,6 +31,12 @@ type EventData =
         filename: string
       }
     }
+  | {
+      type: 'storage:read-bytes'
+      payload: {
+        filename: string
+      }
+    }
 
 // `self` is typed as the base WorkerGlobalScope; assert to the augmented
 // DedicatedWorkerGlobalScope (with fileHandle/accessHandle) declared above.
@@ -131,6 +137,46 @@ onmessage = async (event) => {
           error,
           payload: {
             message: 'error retrieving file',
+          },
+        })
+      }
+      break
+    }
+    case 'storage:read-bytes': {
+      // Reads the raw OPFS bytes so the recorder can embed them in the
+      // Automerge doc at save time (see AudioPlayerContext for the playback
+      // side that reuses the embedded bytes).
+      const { filename } = payload
+      const root = await navigator.storage.getDirectory()
+      try {
+        const handle = await root.getFileHandle(filename)
+        const accessHandle = await handle.createSyncAccessHandle()
+        const fileSize = accessHandle.getSize()
+        const buffer = new ArrayBuffer(fileSize)
+        accessHandle.read(new DataView(buffer), { at: 0 })
+        accessHandle.close()
+        ctx.postMessage(
+          {
+            type: 'storage:read-bytes:response',
+            success: true,
+            payload: {
+              message: 'bytes retrieved',
+              filename,
+              bytes: buffer,
+            },
+          },
+          // Transfer ownership of the buffer to avoid a copy.
+          [buffer],
+        )
+      } catch (error) {
+        console.error('error reading bytes:', error)
+        ctx.postMessage({
+          type: 'storage:read-bytes:response',
+          success: false,
+          error,
+          payload: {
+            message: 'error reading bytes',
+            filename,
           },
         })
       }

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -16,6 +16,7 @@ export type ValidIpcChanel =
   | 'storage:open-directory-dialog'
   | 'storage:edit-recording'
   | 'storage:delete-recording'
+  | 'storage:read-file'
   | 'recorder:start'
   | 'recorder:stop'
   | 'sync:get-server-info'
@@ -76,6 +77,18 @@ export type EditRecordingResponse =
       error: never
     }
 
+export type ReadFileResponse =
+  | {
+      success: false
+      data: never
+      error: Error
+    }
+  | {
+      success: true
+      data: { bytes: Uint8Array; mimeType: string }
+      error: never
+    }
+
 type IpcSendArgs =
   | [
       'settings:set-default-audio-input-device',
@@ -87,6 +100,7 @@ type IpcSendArgs =
       IpcRequest & { data: { filename: string; filepath: string } },
     ]
   | ['storage:delete-recording', IpcRequest & { data: { filepath: string } }]
+  | ['storage:read-file', IpcRequest & { data: { filepath: string } }]
   | [
       'recorder:start',
       IpcRequest & {

--- a/packages/core/app/context/AudioPlayerContext.tsx
+++ b/packages/core/app/context/AudioPlayerContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useEffect, useRef, useState } from 'react'
 import { AutomergeUrl } from '@automerge/automerge-repo'
+import { useDocument } from '@automerge/automerge-repo-react-hooks'
+import { RecordingData } from '@/types'
 import { useAppContext } from './AppContext'
 
 type AudioPlayerContextValue = {
@@ -33,6 +35,10 @@ export const AudioPlayerProvider = ({
   const [currentUrl, setCurrentUrl] = useState<AutomergeUrl | undefined>(
     undefined,
   )
+  // The recording doc for whatever is loaded in the player. When it carries
+  // embedded `audio` bytes (synced from another device) we play those directly,
+  // so a guest can play a recording it never made.
+  const [recordingDoc] = useDocument<RecordingData>(currentUrl)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
   // Mirrors `duration` so `onEnded` can read the latest value without the
@@ -44,6 +50,27 @@ export const AudioPlayerProvider = ({
   useEffect(() => {
     if (!currentSource) {
       return
+    }
+
+    // Prefer bytes embedded in the synced doc. This path is platform-independent
+    // and is the only one that works for a device that did not record the audio
+    // (its OPFS is empty / it has no `tapes://` handler). The bytes may arrive
+    // asynchronously as the doc syncs in, so this effect re-runs when they do.
+    const embeddedAudio = recordingDoc?.audio
+    if (embeddedAudio) {
+      const objectUrl = URL.createObjectURL(
+        // Automerge types the bytes as Uint8Array<ArrayBufferLike>, but BlobPart
+        // wants Uint8Array<ArrayBuffer>; they are identical at runtime.
+        new Blob([embeddedAudio as BlobPart], {
+          type: recordingDoc?.mimeType ?? 'audio/mp4',
+        }),
+      )
+      if (audioRef.current) {
+        audioRef.current.src = objectUrl
+      }
+      return () => {
+        URL.revokeObjectURL(objectUrl)
+      }
     }
 
     const onMessage = async (event: MessageEvent) => {
@@ -83,7 +110,7 @@ export const AudioPlayerProvider = ({
         appContext.worker.removeEventListener('message', onMessage)
       }
     }
-  }, [currentSource, appContext])
+  }, [currentSource, appContext, recordingDoc?.audio, recordingDoc?.mimeType])
 
   useEffect(() => {
     const audio = audioRef.current

--- a/packages/core/app/context/AudioPlayerContext.tsx
+++ b/packages/core/app/context/AudioPlayerContext.tsx
@@ -52,11 +52,19 @@ export const AudioPlayerProvider = ({
       return
     }
 
+    // Wait for the recording doc to resolve before choosing a source. Until it
+    // loads we can't tell whether it has embedded bytes, and falling back to
+    // storage:get here throws NotFoundError for a recording synced from another
+    // device (its bytes are in the doc, not this device's OPFS).
+    if (!recordingDoc) {
+      return
+    }
+
     // Prefer bytes embedded in the synced doc. This path is platform-independent
     // and is the only one that works for a device that did not record the audio
     // (its OPFS is empty / it has no `tapes://` handler). The bytes may arrive
     // asynchronously as the doc syncs in, so this effect re-runs when they do.
-    const embeddedAudio = recordingDoc?.audio
+    const embeddedAudio = recordingDoc.audio
     if (embeddedAudio) {
       const objectUrl = URL.createObjectURL(
         // Automerge types the bytes as Uint8Array<ArrayBufferLike>, but BlobPart

--- a/packages/core/app/types.ts
+++ b/packages/core/app/types.ts
@@ -8,6 +8,12 @@ export type RecordingData = {
   description?: string
   duration: number
   id: string
+  // Raw recorded bytes, embedded so the recording syncs peer-to-peer and can be
+  // played on a device that did not record it. Written once at creation.
+  audio?: Uint8Array
+  // MIME type for the embedded bytes (e.g. 'audio/mp4' on web, 'audio/wav' on
+  // electron), so playback can build a correctly-typed Blob instead of guessing.
+  mimeType?: string
 }
 
 export type RecordingRepoState = {

--- a/packages/core/app/views/Recorder.tsx
+++ b/packages/core/app/views/Recorder.tsx
@@ -13,9 +13,18 @@ import { AudioVisualizer } from '@/components/AudioVisualizer'
 import { getAudioStream, useAutomergeUrl } from '@/utils'
 import { useAppContext } from '@/context/AppContext'
 import { useRecorder } from '@/context/RecordingContext'
-import { IpcResponse, StopRecordingResponse } from '@/IpcService'
+import {
+  IpcResponse,
+  ReadFileResponse,
+  StopRecordingResponse,
+} from '@/IpcService'
 
 const NEW_RECORDING_DEFAULT_NAME = 'New recording'
+
+// Recordings larger than this are not embedded in the synced doc (they would
+// bloat the sync payload and every peer's memory). The recording still plays on
+// the device that made it via the local OPFS/`tapes://` fallback.
+const MAX_EMBEDDED_AUDIO_BYTES = 50 * 1024 * 1024
 
 export function Recorder() {
   const appContext = useAppContext()
@@ -34,6 +43,9 @@ export function Recorder() {
   const { isMonitoring, setIsMonitoring } = useMonitor(audioInputDeviceId)
   const { time, isRecording, handleFilename, setIsRecording } = useRecorder()
   const visualizerContainerRef = useRef<HTMLDivElement | null>(null)
+  // Guards against a second create while the first is still awaiting the byte
+  // read (the doc is now created after async I/O).
+  const isSavingRef = useRef(false)
 
   const [feature, setFeature] = useState<'frequency' | 'time-domain'>(
     'frequency',
@@ -44,10 +56,60 @@ export function Recorder() {
   const [editedName, setEditedName] = useState(NEW_RECORDING_DEFAULT_NAME)
   const [hasErrors, setHasErrors] = useState(false)
 
-  const createRecordingDocument = () => {
+  // Reads the just-recorded bytes so they can be embedded in the doc. On web the
+  // bytes live in OPFS (fetched via the worker); on electron they live on disk
+  // (fetched via the `storage:read-file` IPC channel). `recordingFilepath` is the
+  // OPFS filename on web and an absolute path on electron.
+  const readRecordedBytes = async (
+    recordingFilepath: string,
+  ): Promise<{ bytes: Uint8Array; mimeType: string } | null> => {
+    if (appContext.type === 'web-client') {
+      const { worker } = appContext
+      return new Promise((resolve) => {
+        const onMessage = (event: MessageEvent) => {
+          if (event.data?.type !== 'storage:read-bytes:response') {
+            return
+          }
+          worker.removeEventListener('message', onMessage)
+          if (!event.data.success) {
+            console.error('Failed to read recorded bytes:', event.data.error)
+            resolve(null)
+            return
+          }
+          const { bytes } = event.data.payload as { bytes: ArrayBuffer }
+          // Web recordings are captured as audio/mp4 (see RecordingContext).
+          resolve({ bytes: new Uint8Array(bytes), mimeType: 'audio/mp4' })
+        }
+        worker.addEventListener('message', onMessage)
+        worker.postMessage({
+          type: 'storage:read-bytes',
+          payload: { filename: recordingFilepath },
+        })
+      })
+    }
+
+    const response = await appContext.ipc.send<ReadFileResponse>(
+      'storage:read-file',
+      { data: { filepath: recordingFilepath } },
+    )
+    if (!response.success) {
+      console.error('Failed to read recorded bytes:', response.error)
+      return null
+    }
+    return {
+      bytes: new Uint8Array(response.data.bytes),
+      mimeType: response.data.mimeType,
+    }
+  }
+
+  const createRecordingDocument = async () => {
     if (hasErrors) {
       // TODO: add error feedback
       console.log('Validation errors')
+      return
+    }
+
+    if (isSavingRef.current) {
       return
     }
 
@@ -55,25 +117,50 @@ export function Recorder() {
       setEditedName(NEW_RECORDING_DEFAULT_NAME)
     }
 
-    const handle = repo.create<RecordingData>()
-    const url = handle.url
-    handle.change((doc) => {
-      doc.url = url
-      // Extract the filename from the filepath, and remove the extension
-      doc.filename = filepath.split('.')[0].replace(/(^.+\/)/, '')
-      doc.filepath = filepath
-      doc.name = editedName
-      doc.duration = time
-      doc.id = crypto.randomUUID()
-    })
+    // Capture everything the doc needs before the first `await` — the Save/Enter
+    // handlers reset this state synchronously right after invoking this.
+    const recordingFilepath = filepath
+    const recordingName = editedName || NEW_RECORDING_DEFAULT_NAME
+    const recordingDuration = time
 
-    changeDocState((repoState) => {
-      if (Array.isArray(repoState.recordings)) {
-        repoState.recordings.push(url)
-        return
-      }
-      repoState.recordings = [url]
-    })
+    if (!recordingFilepath) {
+      return
+    }
+
+    isSavingRef.current = true
+    try {
+      const recorded = await readRecordedBytes(recordingFilepath)
+
+      const handle = repo.create<RecordingData>()
+      const url = handle.url
+      handle.change((doc) => {
+        doc.url = url
+        // Extract the filename from the filepath, and remove the extension
+        doc.filename = recordingFilepath.split('.')[0].replace(/(^.+\/)/, '')
+        doc.filepath = recordingFilepath
+        doc.name = recordingName
+        doc.duration = recordingDuration
+        doc.id = crypto.randomUUID()
+        if (recorded && recorded.bytes.byteLength <= MAX_EMBEDDED_AUDIO_BYTES) {
+          doc.audio = recorded.bytes
+          doc.mimeType = recorded.mimeType
+        } else if (recorded) {
+          console.warn(
+            `Recording (${recorded.bytes.byteLength} bytes) exceeds the embed limit; audio will not sync to other devices`,
+          )
+        }
+      })
+
+      changeDocState((repoState) => {
+        if (Array.isArray(repoState.recordings)) {
+          repoState.recordings.push(url)
+          return
+        }
+        repoState.recordings = [url]
+      })
+    } finally {
+      isSavingRef.current = false
+    }
   }
 
   return (
@@ -156,7 +243,7 @@ export function Recorder() {
                 }}
                 onKeyDown={(event) => {
                   if (event.key === 'Enter') {
-                    createRecordingDocument()
+                    void createRecordingDocument()
                     setIsEditing(false)
                     setIsEditorOpen(false)
                     setEditedName(NEW_RECORDING_DEFAULT_NAME)
@@ -198,7 +285,7 @@ export function Recorder() {
                 title="Save recording"
                 className="rounded-full p-4 hover:text-green-500"
                 onClick={() => {
-                  createRecordingDocument()
+                  void createRecordingDocument()
                   setIsEditing(false)
                   setIsEditorOpen(false)
                   setEditedName(NEW_RECORDING_DEFAULT_NAME)


### PR DESCRIPTION
## Context

Closes TAP-57. Follow-up to TAP-56 (hosting the web-client for LAN guests).

Today the synced Automerge document carries **metadata only**. Each recording is its own `RecordingData` doc and the audio bytes live *outside* Automerge — in OPFS (web-client) or on disk served via `tapes://` (electron-client). Only the filename/filepath string syncs, never the bytes. So a guest that syncs the doc gets the recording **list** but an empty local store, and playback fails with `NotFoundError`. A peer could never play a recording it didn't record.

## Approach (candidate #1 from the issue: embed in the doc)

Store the recorded bytes **inline** on the per-recording doc so they sync peer-to-peer like any other doc data.

- **`types.ts`** — add optional `audio?: Uint8Array` + `mimeType?: string` to `RecordingData`. Written **once** at creation, inside the per-recording doc, so there's no history churn and the root list doc stays small.
- **`Recorder.tsx`** — `createRecordingDocument` is now async and embeds the just-recorded bytes:
  - web reads OPFS via a new `storage:read-bytes` worker message;
  - electron reads disk via a new `storage:read-file` IPC channel (`ReadFileChannel`, registered in `index.ts` and whitelisted in `preload.ts`).
  - Guards the async save: captures state before the first `await`, blocks a double-create, and **skips embedding for recordings over 50 MB** (they still play on the device that made them).
- **`AudioPlayerContext.tsx`** — playback **prefers** the doc's embedded bytes (built into a Blob URL — platform-independent, so a guest plays without touching OPFS/`tapes://`) and **falls back** to the existing OPFS/`tapes://` path for legacy recordings on the recorder's own device. The source-resolution effect waits for `useDocument(currentUrl)` to resolve before choosing a source — otherwise it would race the async doc load and post a `storage:get` for a synced recording whose bytes are in the doc (not this device's OPFS), throwing `NotFoundError`.

Embedding runs on **both platforms**, so any synced peer can play any recording (symmetric; no privileged node).

## Content-Security-Policy (required companion change)

The embedded-bytes path plays audio from a `blob:` object URL, which `media-src` governs.

- **electron-client** (`index.html`): its CSP `<meta>` previously only allowed `tapes:` for media, so synced playback was blocked. `media-src` now includes `blob:` (`media-src http://localhost:* tapes: blob:`). Without this, an Electron host silently fails to play synced recordings under CSP.
- **web-client**: no CSP `<meta>`, and its existing OPFS playback already used `blob:` object URLs, so no change was needed there.

## Trade-off

Bytes traverse the sync server and are stored by every peer. Fine for short LAN recordings (the acceptance scenario); the 50 MB guard bounds worst case. The inline field leaves the door open to a later chunked/lazy blob-doc migration if sizes bite.

## Verification

- `yarn build`, `yarn check-types`, `yarn lint` — all green.
- `packages/core` Vitest suite — 6/6 pass.
- **Manual:** record on one device, sync the doc to a web-client guest on a second LAN device, and confirm the guest plays a recording it never made. Reverse direction and legacy-recording fallback should also be checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
