### PR TITLE
fix(electron-client): raise Vite build target to esnext so packaging builds

### DIFF
--- a/apps/electron-client/vite.main.config.ts
+++ b/apps/electron-client/vite.main.config.ts
@@ -10,5 +10,11 @@ export default defineConfig({
   resolve: {
     conditions: ['node'],
   },
+  // The Automerge WASM glue emits top-level await and destructuring; esbuild
+  // can't down-level those to Vite's default browser target, so build for the
+  // modern Electron main runtime (Node) where both are supported natively.
+  build: {
+    target: 'esnext',
+  },
   plugins: [wasm(), topLevelAwait()],
 })

--- a/apps/electron-client/vite.renderer.config.ts
+++ b/apps/electron-client/vite.renderer.config.ts
@@ -34,5 +34,11 @@ export default defineConfig({
       ),
     },
   },
+  // The Automerge WASM glue emits top-level await and destructuring; esbuild
+  // can't down-level those to Vite's default browser target, so build for the
+  // modern Electron renderer (Chromium) where both are supported natively.
+  build: {
+    target: 'esnext',
+  },
   plugins: [react(), wasm(), topLevelAwait(), devCspAllowInlineStyles()],
 })


### PR DESCRIPTION
## Problem

`yarn package` (electron-forge) failed during the production build with 300+ esbuild errors:

```
[plugin vite-plugin-top-level-await]
Error: Transform failed with 317 errors:
<stdin>:8738:15: ERROR: Transforming destructuring to the configured target environment
("chrome87", "edge88", "es2020", "firefox78", "safari14") is not supported yet
```

`vite-plugin-top-level-await` re-runs the bundle through esbuild. Both `vite.main.config.ts` and `vite.renderer.config.ts` left `build.target` at Vite's default (`es2020`), and the Automerge 3 WASM glue emits top-level `await` + destructuring that esbuild can't down-level to that target. `yarn dev` was unaffected because the dev path doesn't enforce that transform — only the production `package` build does.

## Fix

Set `build.target: 'esnext'` in both configs. The Electron main process (Node) and renderer (Chromium 130+ in Electron 43) support top-level await and destructuring natively, so there's nothing to down-level.

## Verification

- `vite build --config vite.renderer.config.ts` → ✓ built (was 314 errors)
- `vite build --config vite.main.config.ts` → ✓ built (was 331 errors)
- `yarn check-types` → clean
- `yarn eslint` on both files → clean

## Note (out of scope)

This unblocks the **build** stage only. `yarn package` then proceeds into codesigning, where `forge.config.ts` hardcodes `osxSign`/`osxNotarize` while the machine has no valid signing identity — a separate change if local unsigned packages are wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)