### PR TITLE
fix(electron-client): skip notarization when no Developer ID cert is present

### DIFF
--- a/apps/electron-client/forge.config.ts
+++ b/apps/electron-client/forge.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from 'node:child_process'
 import type { ForgeConfig } from '@electron-forge/shared-types'
 import { MakerSquirrel } from '@electron-forge/maker-squirrel'
 import { MakerZIP } from '@electron-forge/maker-zip'
@@ -14,6 +15,30 @@ const notarizeOptions = {
   teamId: process.env.APPLE_TEAM_ID ?? '',
 } as const
 
+// Notarization requires a real "Developer ID Application" certificate: Apple
+// rejects the ad-hoc signature that `osxSign: {}` falls back to when no cert is
+// installed. Detect a usable identity so local `yarn package` runs produce an
+// ad-hoc-signed build and skip notarization, while CI/release machines that
+// have imported a Developer ID cert (and set the APPLE_* creds) still notarize.
+function hasDeveloperIdCertificate(): boolean {
+  try {
+    const identities = execSync('security find-identity -v -p codesigning', {
+      encoding: 'utf8',
+    })
+    return identities.includes('Developer ID Application')
+  } catch {
+    return false
+  }
+}
+
+const canNotarize =
+  hasDeveloperIdCertificate() &&
+  Boolean(
+    process.env.APPLE_ID &&
+      process.env.APPLE_PASSWORD &&
+      process.env.APPLE_TEAM_ID,
+  )
+
 const repositoryOptions = {
   owner: process.env.REPO_OWNER ?? '',
   name: process.env.REPO_NAME ?? '',
@@ -23,7 +48,7 @@ const config: ForgeConfig = {
   packagerConfig: {
     asar: true,
     osxSign: {},
-    osxNotarize: notarizeOptions,
+    ...(canNotarize ? { osxNotarize: notarizeOptions } : {}),
     extraResource: [
       'bin/sox-14.4.2-macOS',
       'bin/SwitchAudioSource-1.2.2-macOS',


### PR DESCRIPTION
## Problem

After the Vite target fix (#257), `yarn package` reached codesigning and failed:

```
Error: Failed to codesign your application with code: 1
tapes-electron-client.app: invalid Info.plist (plist or signature have been modified)
...
Signature=adhoc
TeamIdentifier=not set
    at @electron/notarize/lib/check-signature.js:74:19
```

`osxSign: {}` ad-hoc signs the app when no signing certificate is installed. `osxNotarize` (unconditionally configured) then runs a pre-flight signature check that Apple's notarize tooling **rejects for ad-hoc builds**. So `yarn package` was broken on any machine without a Developer ID certificate — i.e. local development.

## Fix

`forge.config.ts` now detects a real `Developer ID Application` identity via `security find-identity -v -p codesigning` and only attaches `osxNotarize` when one is present (together with the `APPLE_*` credentials).

- **Local (no cert):** app is ad-hoc signed, notarization skipped, `yarn package` succeeds.
- **CI / release (cert imported + creds):** signs and notarizes exactly as before.

`osxSign: {}` is unchanged, so real Developer ID signing is still auto-selected when a cert exists.

## Verification

Ran the full `electron-forge package` locally (no Developer ID cert on the machine):

- ✅ Build → package for arm64/darwin → `postPackage` all pass, no codesign error
- ✅ Output `tapes-electron-client.app` produced; `codesign -dvv` shows `Signature=adhoc` (notarization correctly skipped)
- ✅ `yarn check-types` and `yarn eslint forge.config.ts` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)