### PR TITLE
fix(core): include whole stringified MediaDeviceInfo object in options

### DIFF
--- a/apps/web-client/e2e/device-switch.spec.ts
+++ b/apps/web-client/e2e/device-switch.spec.ts
@@ -2,18 +2,19 @@ import {
   test,
   expect,
   openApp,
-  deviceOptionValues,
+  deviceOptions,
   selectDevice,
   recordFor,
   saveRecording,
   readState,
+  storedAudioInputDeviceId,
 } from './fixtures'
 
 test.describe('input device selection', () => {
   test('records from the newly selected device', async ({ page }) => {
     await openApp(page)
 
-    const devices = await deviceOptionValues(page)
+    const devices = await deviceOptions(page)
     // CI provides two PulseAudio virtual sources; a laptop with a single mic
     // should skip rather than fail.
     test.skip(devices.length < 2, 'needs at least two audio input devices')
@@ -39,10 +40,54 @@ test.describe('input device selection', () => {
     // a bare (ideal) `deviceId`, which Chromium ignores, so both recordings
     // came from the system default. These assert the track really is the
     // device that was asked for.
-    expect(constructions[0].trackDeviceId).toBe(deviceA)
-    expect(constructions[1].trackDeviceId).toBe(deviceB)
+    expect(constructions[0].trackDeviceId).toBe(deviceA.deviceId)
+    expect(constructions[1].trackDeviceId).toBe(deviceB.deviceId)
     expect(constructions[1].trackDeviceId).not.toBe(
       constructions[0].trackDeviceId,
     )
+  })
+
+  // The option value carries the whole device so the electron client can read
+  // `label` (switchaudio-osx matches on device name) while the web client reads
+  // `deviceId`. What gets *persisted* is still only the deviceId — if the JSON
+  // blob ever leaked into settings, getUserMedia would be handed a constraint
+  // it cannot match.
+  test('serializes the whole device into the option but persists only its id', async ({
+    page,
+  }) => {
+    await openApp(page)
+
+    const devices = await deviceOptions(page)
+    expect(devices.length).toBeGreaterThan(0)
+    const [device] = devices
+
+    const parsed = JSON.parse(device.value) as MediaDeviceInfo
+    expect(parsed.deviceId).toBe(device.deviceId)
+    expect(parsed.kind).toBe('audioinput')
+    expect(parsed.label).toBe(device.label)
+    expect(parsed).toHaveProperty('groupId')
+
+    // The option's visible text is the plain label, not the JSON.
+    await expect(
+      page.locator('option', { hasText: device.label }).first(),
+    ).toHaveText(device.label)
+
+    await selectDevice(page, device)
+
+    await expect
+      .poll(() => storedAudioInputDeviceId(page))
+      .toBe(device.deviceId)
+
+    // And the recording path really receives that id as a constraint.
+    await recordFor(page, 1000)
+    const { gumConstraints } = await readState(page)
+    const audioConstraints = gumConstraints
+      .map((constraint) => constraint.audio)
+      .filter(
+        (audio): audio is MediaTrackConstraints =>
+          typeof audio === 'object' && audio !== null,
+      )
+    expect(audioConstraints.length).toBeGreaterThan(0)
+    expect(JSON.stringify(audioConstraints)).toContain(device.deviceId)
   })
 })

--- a/apps/web-client/e2e/fixtures.ts
+++ b/apps/web-client/e2e/fixtures.ts
@@ -91,8 +91,24 @@ export const openApp = async (page: Page) => {
   await expect(page.getByRole('button', { name: 'Recorder' })).toBeVisible()
 }
 
-/** Device ids offered by AudioInputSelector, minus its placeholder option. */
-export const deviceOptionValues = async (page: Page) => {
+/** One entry per non-placeholder option in AudioInputSelector. */
+export type DeviceOption = {
+  /** What the app persists and later passes as a getUserMedia constraint. */
+  deviceId: string
+  /** The option's visible text, and what the electron client sends over IPC. */
+  label: string
+  /** The raw option value: a stringified MediaDeviceInfo. */
+  value: string
+}
+
+/**
+ * Audio input devices offered by AudioInputSelector, minus its placeholder.
+ *
+ * Option values are whole stringified MediaDeviceInfo objects, not bare device
+ * ids — the two clients need different fields off the same option, so the
+ * selector serializes the lot and each reads what it needs.
+ */
+export const deviceOptions = async (page: Page): Promise<DeviceOption[]> => {
   const select = page.getByRole('combobox').first()
 
   // AudioInputSelector renders an "Allow access" button until its permission
@@ -109,25 +125,45 @@ export const deviceOptionValues = async (page: Page) => {
     await select.waitFor({ state: 'visible', timeout: 10_000 })
   }
 
-  return select
+  const values = await select
     .locator('option')
     .evaluateAll((options) =>
       options
         .map((option) => (option as HTMLOptionElement).value)
         .filter((value) => value !== ''),
     )
+
+  return values.map((value) => {
+    const parsed = JSON.parse(value) as MediaDeviceInfo
+    return { deviceId: parsed.deviceId, label: parsed.label, value }
+  })
 }
 
-export const selectDevice = async (page: Page, deviceId: string) => {
+export const selectDevice = async (page: Page, device: DeviceOption) => {
   // Target the select that actually offers this device rather than a
   // positional one. The Settings view has three comboboxes (input device,
   // recording format, channels) and the device selector populates last —
   // it waits on a permissions query and enumerateDevices — so `.first()`
   // races it and lands on the format select on a slow machine.
-  const select = page.locator(`select:has(option[value="${deviceId}"])`)
+  //
+  // Matched by option *text*, not by an `option[value="..."]` CSS selector:
+  // the value is now JSON, whose quotes and braces would have to be escaped
+  // into the selector. `hasText` takes a plain string.
+  const select = page
+    .locator('select')
+    .filter({ has: page.locator('option', { hasText: device.label }) })
   await expect(select).toBeVisible()
-  await select.selectOption(deviceId)
+  await select.selectOption({ label: device.label })
 }
+
+/** The audioInputDeviceId the app has persisted, if any. */
+export const storedAudioInputDeviceId = (page: Page) =>
+  page.evaluate(() => {
+    const settings = JSON.parse(localStorage.getItem('settings') ?? '{}') as {
+      audioInputDeviceId?: string
+    }
+    return settings.audioInputDeviceId
+  })
 
 /**
  * Records for `durationMs`. Four seconds by default: at one second Chromium

--- a/apps/web-client/e2e/recording.spec.ts
+++ b/apps/web-client/e2e/recording.spec.ts
@@ -2,7 +2,7 @@ import {
   test,
   expect,
   openApp,
-  deviceOptionValues,
+  deviceOptions,
   selectDevice,
   recordFor,
   saveRecording,
@@ -16,7 +16,7 @@ test.describe('recording', () => {
   }) => {
     await openApp(page)
 
-    const devices = await deviceOptionValues(page)
+    const devices = await deviceOptions(page)
     expect(devices.length).toBeGreaterThan(0)
     await selectDevice(page, devices[0])
 

--- a/apps/web-client/e2e/strict-mode.spec.ts
+++ b/apps/web-client/e2e/strict-mode.spec.ts
@@ -2,7 +2,7 @@ import {
   test,
   expect,
   openApp,
-  deviceOptionValues,
+  deviceOptions,
   selectDevice,
   recordFor,
   expectRecordedBytes,
@@ -28,7 +28,7 @@ test.describe('StrictMode', () => {
       'expected the dev server, where StrictMode double-invokes effects',
     ).toBe(true)
 
-    const devices = await deviceOptionValues(page)
+    const devices = await deviceOptions(page)
     expect(devices.length).toBeGreaterThan(0)
     await selectDevice(page, devices[0])
 

--- a/packages/core/app/components/AudioInputSelector.test.tsx
+++ b/packages/core/app/components/AudioInputSelector.test.tsx
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  render,
+  screen,
+  cleanup,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react'
+import { AppContextProvider } from '@/context/AppContext'
+import type { AppContextValue } from '@/context/AppContext'
+import { SettingsProvider } from '@/context/SettingsContext'
+import type { IpcService } from '@/IpcService'
+import { AudioInputSelector } from './AudioInputSelector'
+
+// The device list the component renders. `default` and `(Virtual)` entries are
+// filtered out by the component, so they double as a guard that the filters
+// survive the option-value change.
+const builtInMic = {
+  deviceId: 'built-in-id',
+  kind: 'audioinput',
+  label: 'MacBook Pro Microphone',
+  groupId: 'group-built-in',
+} as MediaDeviceInfo
+
+const usbMic = {
+  deviceId: 'usb-id',
+  kind: 'audioinput',
+  label: 'Scarlett Solo USB',
+  groupId: 'group-usb',
+} as MediaDeviceInfo
+
+const devices = [
+  { ...builtInMic, deviceId: 'default', label: 'Default' } as MediaDeviceInfo,
+  builtInMic,
+  usbMic,
+  {
+    deviceId: 'virtual-id',
+    kind: 'audioinput',
+    label: 'BlackHole (Virtual)',
+    groupId: 'group-virtual',
+  } as MediaDeviceInfo,
+  {
+    deviceId: 'speaker-id',
+    kind: 'audiooutput',
+    label: 'MacBook Pro Speakers',
+    groupId: 'group-built-in',
+  } as MediaDeviceInfo,
+]
+
+const enumerateDevices = vi.fn(async () => devices)
+const getUserMedia = vi.fn(async () => ({}) as MediaStream)
+const permissionsQuery = vi.fn(async () => ({ state: 'granted' }))
+
+function stubNavigator() {
+  Object.defineProperty(navigator, 'permissions', {
+    configurable: true,
+    value: { query: permissionsQuery },
+  })
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { enumerateDevices, getUserMedia },
+  })
+}
+
+const ipcSend = vi.fn(async () => ({ error: undefined }))
+
+const electronContext = {
+  type: 'electron-client',
+  ipc: { send: ipcSend } as unknown as IpcService,
+} satisfies AppContextValue
+
+const webContext = {
+  type: 'web-client',
+  worker: {} as unknown as Worker,
+} satisfies AppContextValue
+
+async function renderSelector(appContext: AppContextValue) {
+  render(
+    <AppContextProvider value={appContext}>
+      <SettingsProvider>
+        <AudioInputSelector />
+      </SettingsProvider>
+    </AppContextProvider>,
+  )
+  return waitFor(() => screen.getByRole('combobox'))
+}
+
+function storedDeviceId() {
+  return JSON.parse(localStorage.getItem('settings') ?? '{}')
+    .audioInputDeviceId as string | undefined
+}
+
+describe('AudioInputSelector option values', () => {
+  beforeEach(() => {
+    stubNavigator()
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  // The fix: an option carries the whole MediaDeviceInfo, not just the label
+  // (electron) or the deviceId (web), so both platforms can read either field.
+  it.each([
+    ['electron-client', electronContext],
+    ['web-client', webContext],
+  ] as const)(
+    'stringifies the whole device object into the option value on %s',
+    async (_name, appContext) => {
+      await renderSelector(appContext)
+
+      const option = screen.getByRole('option', {
+        name: usbMic.label,
+      }) as HTMLOptionElement
+
+      expect(JSON.parse(option.value)).toEqual(usbMic)
+    },
+  )
+
+  it('keeps the empty placeholder option value empty', async () => {
+    await renderSelector(webContext)
+
+    const placeholder = screen.getByRole('option', {
+      name: 'Select an audio input device',
+    }) as HTMLOptionElement
+
+    expect(placeholder.value).toBe('')
+  })
+
+  it('lists only non-default, non-virtual audio inputs', async () => {
+    await renderSelector(webContext)
+
+    expect(
+      screen.getAllByRole('option').map((option) => option.textContent),
+    ).toEqual(['Select an audio input device', builtInMic.label, usbMic.label])
+  })
+})
+
+describe('AudioInputSelector selection', () => {
+  beforeEach(() => {
+    stubNavigator()
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('persists the deviceId, not the serialized object, on electron', async () => {
+    const select = await renderSelector(electronContext)
+
+    fireEvent.change(select, { target: { value: JSON.stringify(usbMic) } })
+
+    await waitFor(() => expect(storedDeviceId()).toBe(usbMic.deviceId))
+  })
+
+  it('persists the deviceId on web', async () => {
+    const select = await renderSelector(webContext)
+
+    fireEvent.change(select, { target: { value: JSON.stringify(usbMic) } })
+
+    await waitFor(() => expect(storedDeviceId()).toBe(usbMic.deviceId))
+  })
+
+  // switchaudio-osx identifies devices by name, so the IPC payload must still
+  // be the label even though the option value is now a JSON blob.
+  it('sends the device label over IPC on electron', async () => {
+    const select = await renderSelector(electronContext)
+
+    fireEvent.change(select, { target: { value: JSON.stringify(usbMic) } })
+
+    await waitFor(() =>
+      expect(ipcSend).toHaveBeenCalledWith(
+        'settings:set-default-audio-input-device',
+        { data: { deviceName: usbMic.label } },
+      ),
+    )
+  })
+
+  it('does not touch IPC on web', async () => {
+    const select = await renderSelector(webContext)
+
+    fireEvent.change(select, { target: { value: JSON.stringify(usbMic) } })
+
+    await waitFor(() => expect(storedDeviceId()).toBe(usbMic.deviceId))
+    expect(ipcSend).not.toHaveBeenCalled()
+  })
+
+  it('clears the setting when the placeholder option is chosen', async () => {
+    const select = await renderSelector(webContext)
+
+    fireEvent.change(select, { target: { value: JSON.stringify(usbMic) } })
+    await waitFor(() => expect(storedDeviceId()).toBe(usbMic.deviceId))
+
+    fireEvent.change(select, { target: { value: '' } })
+
+    await waitFor(() => expect(storedDeviceId()).toBe(''))
+  })
+
+  it('still stores the deviceId when the IPC call fails', async () => {
+    ipcSend.mockResolvedValueOnce({
+      error: 'no such device',
+    } as unknown as { error: undefined })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const select = await renderSelector(electronContext)
+    fireEvent.change(select, { target: { value: JSON.stringify(usbMic) } })
+
+    await waitFor(() => expect(storedDeviceId()).toBe(usbMic.deviceId))
+    consoleError.mockRestore()
+  })
+})
+
+describe('AudioInputSelector initial selection', () => {
+  beforeEach(() => {
+    stubNavigator()
+    localStorage.clear()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  // The persisted setting is a deviceId while option values are JSON, so the
+  // component has to look the device back up to preselect it.
+  it('preselects the stored device by looking its deviceId back up', async () => {
+    // audioChannelCount/audioFormat have to be present or SettingsContext
+    // discards the rest of the stored settings on read.
+    localStorage.setItem(
+      'settings',
+      JSON.stringify({
+        audioChannelCount: '1',
+        audioFormat: 'wav',
+        audioInputDeviceId: usbMic.deviceId,
+      }),
+    )
+
+    const select = (await renderSelector(webContext)) as HTMLSelectElement
+
+    await waitFor(() => expect(JSON.parse(select.value)).toEqual(usbMic))
+  })
+
+  it('falls back to the placeholder when no device is stored', async () => {
+    const select = (await renderSelector(webContext)) as HTMLSelectElement
+
+    await waitFor(() => expect(screen.getAllByRole('option')).toHaveLength(3))
+    expect(select.value).toBe('')
+  })
+})

--- a/packages/core/app/components/AudioInputSelector.tsx
+++ b/packages/core/app/components/AudioInputSelector.tsx
@@ -79,14 +79,19 @@ export function AudioInputSelector({ className }: { className?: string }) {
           setAudioInputDeviceId('')
           return
         }
+
+        // TODO: validate parsedMediaDeviceInfo
+        const parsedMediaDeviceInfo = JSON.parse(event.target.value) as MediaDeviceInfo
+
         if (appContext.type === 'electron-client') {
           try {
+
             const setAudioInputDeviceResponse =
               await appContext.ipc.send<IpcResponse>(
                 'settings:set-default-audio-input-device',
                 {
                   data: {
-                    deviceName: event.target.value,
+                    deviceName: parsedMediaDeviceInfo.label
                   },
                 },
               )
@@ -97,19 +102,15 @@ export function AudioInputSelector({ className }: { className?: string }) {
             console.error('Error setting default audio input device:', error)
           }
         }
-        setAudioInputDeviceId(event.target.value)
+        setAudioInputDeviceId(parsedMediaDeviceInfo.deviceId)
       }}
-      defaultValue={audioInputDeviceId ?? ''}
+      defaultValue={JSON.stringify(audioInputDevices.find(device => device.deviceId === audioInputDeviceId)) ?? ''}
     >
       <option value="">Select an audio input device</option>
       {audioInputDevices.map((device) => (
         <option
           key={device.deviceId}
-          value={
-            appContext.type === 'electron-client'
-              ? device.label
-              : device.deviceId
-          }
+          value={JSON.stringify(device)}
         >
           {device.label}
         </option>

--- a/packages/core/app/components/AudioInputSelector.tsx
+++ b/packages/core/app/components/AudioInputSelector.tsx
@@ -133,3 +133,4 @@ const isValidMediaDeviceInfo = (parsed: unknown): parsed is MediaDeviceInfo =>
   && parsed.deviceId.length > 0
   && 'label' in parsed
   && typeof parsed.label === 'string'
+  

--- a/packages/core/app/components/AudioInputSelector.tsx
+++ b/packages/core/app/components/AudioInputSelector.tsx
@@ -80,8 +80,14 @@ export function AudioInputSelector({ className }: { className?: string }) {
           return
         }
 
-        // TODO: validate parsedMediaDeviceInfo
-        const parsedMediaDeviceInfo = JSON.parse(event.target.value) as MediaDeviceInfo
+        let parsedMediaDeviceInfo: unknown
+        try {
+          parsedMediaDeviceInfo = JSON.parse(event.target.value)
+        } catch {
+          console.error('Unparseable audio input option value')
+          return
+        }
+        if (!isValidMediaDeviceInfo(parsedMediaDeviceInfo)) return
 
         if (appContext.type === 'electron-client') {
           try {
@@ -118,3 +124,12 @@ export function AudioInputSelector({ className }: { className?: string }) {
     </select>
   )
 }
+
+const isValidMediaDeviceInfo = (parsed: unknown): parsed is MediaDeviceInfo =>
+  typeof parsed === 'object' 
+  && parsed !== null 
+  && 'deviceId' in parsed
+  && typeof parsed.deviceId === 'string'
+  && parsed.deviceId.length > 0
+  && 'label' in parsed
+  && typeof parsed.label === 'string'

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
   ],
   build: {
     emptyOutDir: false,
+    // Emit .js.map files alongside the bundle so consumers (the electron
+    // renderer, web-client) show core's original .tsx sources in devtools
+    // instead of the built output.
+    sourcemap: true,
     // esnext so esbuild doesn't try to downlevel the top-level-await /
     // destructuring output; the consuming apps set their own build target.
     target: 'esnext',


### PR DESCRIPTION
`AudioInputSelector` served a different option value per platform — the device
label on electron, the deviceId on web — so neither client could reach the other's
field. Options now carry the whole stringified `MediaDeviceInfo`: electron reads
`label` for `switchaudio-osx`, web reads `deviceId`, and only the deviceId is
persisted. `defaultValue` looks the stored deviceId back up to preselect its option.

`JSON.parse` on the option value is wrapped in a `try`/`catch`, and
`isValidMediaDeviceInfo` narrows the result instead of an unchecked `as` cast.

**Tests** — 12 new unit tests in `packages/core` cover the serialized option value,
the electron IPC payload, deviceId-only persistence (including when the IPC call
fails), clearing via the placeholder, and preselection. The web-client e2e helpers
assumed bare deviceId values and located the `<select>` with an `option[value="…"]`
CSS selector that JSON quotes can't survive; `deviceOptions` now returns
`{ deviceId, label, value }` and `selectDevice` matches on option text.

Verified: 18/18 core unit tests, 6/6 e2e. Against the pre-fix component, 9 of 12
unit tests and both `device-switch` e2e tests fail.