### PR TITLE
feat(core): make sync optional in core App.tsx and enable cross tab broadcast (TAP-64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Build
         run: yarn build
 
-      # Scoped to core: apps/api has its own (Jest) suite with a pre-existing
-      # compile failure unrelated to this gate, so run only the package whose
+      # Explicitly scoped: apps/api has its own (Jest) suite with a pre-existing
+      # compile failure unrelated to this gate, so run only the workspaces whose
       # unit tests this step is meant to guard.
       - name: Unit Tests
-        run: yarn turbo test --filter=@tapes-monorepo/core
+        run: yarn turbo test --filter=@tapes-monorepo/core --filter=electron-client
 
   e2e:
     name: E2E (web-client)

--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -15,6 +15,8 @@
     "publish": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge publish",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "rm -rf .vite",
     "pull": "vercel env pull .env.local"
   },
@@ -57,7 +59,8 @@
     "vite": "^8.1.5",
     "vite-plugin-require": "^1.2.14",
     "vite-plugin-top-level-await": "^1.6.0",
-    "vite-plugin-wasm": "^3.6.0"
+    "vite-plugin-wasm": "^3.6.0",
+    "vitest": "^3.0.0"
   },
   "peerDependencies": {
     "esbuild-register": "*",

--- a/apps/electron-client/src/renderer.tsx
+++ b/apps/electron-client/src/renderer.tsx
@@ -52,10 +52,6 @@ function ElectronAppRoot() {
       })
   }, [syncServerUrl])
 
-  if (!syncServerUrl) {
-    return null
-  }
-
   return <App appContextValue={appContextValue} syncServerUrl={syncServerUrl} />
 }
 

--- a/apps/electron-client/src/syncServer.test.ts
+++ b/apps/electron-client/src/syncServer.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { afterEach, describe, expect, it } from 'vitest'
+import { startSyncServer, stopSyncServer } from './syncServer'
+
+let storagePath: string | undefined
+
+afterEach(async () => {
+  await stopSyncServer()
+  if (storagePath) {
+    await rm(storagePath, { recursive: true, force: true })
+    storagePath = undefined
+  }
+})
+
+async function startForTest() {
+  storagePath = await mkdtemp(path.join(tmpdir(), 'tapes-sync-'))
+  return startSyncServer({
+    storagePath,
+    host: '127.0.0.1',
+    // 0 lets the OS pick a free port so the suite never collides with a
+    // running desktop app on the default port.
+    port: 0,
+    peerId: 'test-host',
+  })
+}
+
+function connect(url: string) {
+  return new Promise<void>((resolve, reject) => {
+    const socket = new WebSocket(url)
+    socket.on('open', () => {
+      socket.close()
+      resolve()
+    })
+    socket.on('error', reject)
+  })
+}
+
+describe('startSyncServer', () => {
+  // The web client derives its sync URL as `<origin>/sync` in every mode
+  // (see apps/web-client/src/main.tsx): in development Vite proxies that path
+  // here, and in production this server receives it verbatim. That only works
+  // because the WebSocket server is attached to the whole http server rather
+  // than a route, so it must keep accepting the upgrade on a non-root path.
+  it('accepts a sync socket on the /sync path', async () => {
+    const info = await startForTest()
+
+    await expect(connect(`${info.url}/sync`)).resolves.toBeUndefined()
+  })
+
+  it('accepts a sync socket on the root path', async () => {
+    const info = await startForTest()
+
+    await expect(connect(info.url)).resolves.toBeUndefined()
+  })
+})

--- a/apps/electron-client/vitest.config.ts
+++ b/apps/electron-client/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+// Node-environment unit tests for the main-process modules. The `@/` alias
+// mirrors tsconfig.json so imports resolve the same way under test.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/apps/web-client/.env.example
+++ b/apps/web-client/.env.example
@@ -2,7 +2,7 @@
 # See apps/web-client/README.md.
 
 # Optional build-time override for the sync-server URL (e.g. a Vercel deploy).
-# Leave unset to derive the URL from window.location / the /sync dev proxy.
+# Leave unset to derive `<origin>/sync` from window.location.
 VITE_SYNC_SERVER_URL=
 
 # The following are normally set by the dev scripts, not by hand:

--- a/apps/web-client/README.md
+++ b/apps/web-client/README.md
@@ -9,10 +9,11 @@ This same bundle runs in two places:
 - **Standalone** in a browser (e.g. the Vercel-hosted PWA).
 - **Embedded** in the desktop host (`electron-client`) and served to LAN guests.
 
-The sync-server URL is resolved at runtime in `src/main.tsx`: when served by the
-Electron host it's the same origin; in dev it reaches the host's embedded sync
-server through the `/sync` proxy (see `vite.config.ts`); a build-time
-`VITE_SYNC_SERVER_URL` (the Vercel deploy path) takes precedence.
+The sync-server URL is resolved at runtime in `src/main.tsx`: it is always
+`/sync` on the origin serving the bundle. The Electron host accepts the socket
+upgrade on any path, and in dev the Vite dev server proxies `/sync` back to that
+host (see `vite.config.ts`). A build-time `VITE_SYNC_SERVER_URL` (the Vercel
+deploy path) takes precedence.
 
 ## Develop
 

--- a/apps/web-client/src/main.tsx
+++ b/apps/web-client/src/main.tsx
@@ -4,20 +4,16 @@ import { App } from '@tapes-monorepo/core'
 import './index.css'
 import DownloadPrompt from './DownloadPrompt'
 
-// When the bundle is served from the Electron host, the sync server lives on
-// the same origin, so derive the URL from window.location. In development the
-// bundle is instead served by this package's own Vite dev server (for HMR), and
-// the sync socket reaches the host's embedded sync server through the `/sync`
-// proxy (see vite.config.ts). A build-time VITE_SYNC_SERVER_URL (the Vercel
-// deploy path) still takes precedence.
+// The sync socket always lives at `/sync` on the same origin as this bundle.
+// When the Electron host serves the bundle it accepts the upgrade on any path
+// (its WebSocketServer is attached to the whole http server, not a route), and
+// in development the bundle is served by this package's own Vite dev server
+// (for HMR), which proxies `/sync` back to that host (see vite.config.ts). A
+// build-time VITE_SYNC_SERVER_URL (the Vercel deploy path) takes precedence.
 const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
-// `import.meta.env.DEV` is a Vite build-time boolean (dev server vs. static
-// build), not a process env var; the disable is for turbo's env-var lint rule.
-// eslint-disable-next-line turbo/no-undeclared-env-vars
-const servedByDevServer = import.meta.env.DEV
 const syncServerUrl =
   import.meta.env.VITE_SYNC_SERVER_URL ??
-  `${scheme}://${window.location.host}${servedByDevServer ? '/sync' : ''}`
+  `${scheme}://${window.location.host}/sync`
 
 if (!window.Worker) {
   ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/packages/core/app/App.test.tsx
+++ b/packages/core/app/App.test.tsx
@@ -1,0 +1,234 @@
+import { StrictMode } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import type { AutomergeUrl } from '@automerge/automerge-repo'
+import type { AppContextValue } from '@/context/AppContext'
+import { App } from './App'
+
+const STORED_URL = 'automerge:stored-doc'
+const CREATED_URL = 'automerge:created-doc' as AutomergeUrl
+
+// Every Repo construction, so tests can assert on the network array App built.
+const { repoConfigs, findCalls, createCalls, control } = vi.hoisted(() => ({
+  repoConfigs: [] as { network: unknown[]; storage: unknown }[],
+  findCalls: [] as string[],
+  createCalls: [] as unknown[],
+  // Lets one test hold find() open so App is observed mid-initialization.
+  control: { blockFind: false },
+}))
+
+// Hoisted: vi.mock factories run before the module body, so the stand-in
+// adapters have to exist by then.
+const { FakeBroadcastAdapter, FakeWebSocketAdapter, FakeStorageAdapter } =
+  vi.hoisted(() => ({
+    FakeBroadcastAdapter: class {
+      readonly kind = 'broadcast'
+    },
+    FakeWebSocketAdapter: class {
+      readonly kind = 'websocket'
+      constructor(public url: string) {}
+    },
+    FakeStorageAdapter: class {
+      readonly kind = 'indexeddb'
+    },
+  }))
+
+vi.mock('@automerge/automerge-repo-network-broadcastchannel', () => ({
+  BroadcastChannelNetworkAdapter: FakeBroadcastAdapter,
+}))
+
+vi.mock('@automerge/automerge-repo-network-websocket', () => ({
+  BrowserWebSocketClientAdapter: FakeWebSocketAdapter,
+}))
+
+vi.mock('@automerge/automerge-repo-storage-indexeddb', () => ({
+  IndexedDBStorageAdapter: FakeStorageAdapter,
+}))
+
+vi.mock('@automerge/automerge-repo', () => ({
+  isValidAutomergeUrl: (url: string) => url.startsWith('automerge:'),
+  Repo: class {
+    constructor(config: { network: unknown[]; storage: unknown }) {
+      repoConfigs.push(config)
+    }
+    async find(url: string) {
+      findCalls.push(url)
+      if (control.blockFind) {
+        await new Promise(() => {})
+      }
+      return { url }
+    }
+    create(initialValue: unknown) {
+      createCalls.push(initialValue)
+      return { url: CREATED_URL }
+    }
+  },
+}))
+
+// The view tree below App is irrelevant here — these tests are about how App
+// wires up the Repo — so collapse the providers and children to a marker that
+// tells us the async initialize() finished and `repo` state landed.
+vi.mock('./context/Providers', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="providers">{children}</div>
+  ),
+}))
+
+vi.mock('@/context/ViewContext', () => ({
+  useView: () => ({ currentView: 'recorder', setCurrentView: vi.fn() }),
+  navigationConfig: [],
+  viewComponentMap: { recorder: null },
+}))
+
+vi.mock('./context/AudioPlayerContext', () => ({
+  useAudioPlayer: () => ({ currentUrl: undefined }),
+}))
+
+vi.mock('./components/AudioPlayer', () => ({
+  AudioPlayer: () => null,
+}))
+
+const appContextValue: AppContextValue = {
+  type: 'web-client',
+  worker: {} as unknown as Worker,
+}
+
+const renderApp = async (
+  syncServerUrl?: string | null,
+  { strict = false }: { strict?: boolean } = {},
+) => {
+  const tree = (
+    <App appContextValue={appContextValue} syncServerUrl={syncServerUrl} />
+  )
+  render(strict ? <StrictMode>{tree}</StrictMode> : tree)
+  await screen.findByTestId('providers')
+}
+
+const networkOf = (index = 0) => repoConfigs[index].network
+const adaptersOfKind = (kind: string, index = 0) =>
+  networkOf(index).filter(
+    (adapter) => (adapter as { kind: string }).kind === kind,
+  )
+
+beforeEach(() => {
+  repoConfigs.length = 0
+  findCalls.length = 0
+  createCalls.length = 0
+  control.blockFind = false
+  localStorage.clear()
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('App network adapters', () => {
+  it('builds a repo with only the broadcast adapter when no sync url is given', async () => {
+    await renderApp(undefined)
+
+    expect(repoConfigs).toHaveLength(1)
+    expect(networkOf()).toHaveLength(1)
+    expect(adaptersOfKind('broadcast')).toHaveLength(1)
+    expect(adaptersOfKind('websocket')).toHaveLength(0)
+  })
+
+  // The point of making the prop optional: these are the values the call sites
+  // can hand over when there is no sync server, and none may produce a socket
+  // that then loops on failing reconnects.
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+  ])(
+    'adds no websocket adapter when the sync url is %s',
+    async (_label, url) => {
+      await renderApp(url)
+
+      expect(adaptersOfKind('websocket')).toHaveLength(0)
+    },
+  )
+
+  it('adds a websocket adapter pointed at the sync url when one is given', async () => {
+    await renderApp('ws://192.168.1.2:9001')
+
+    expect(networkOf()).toHaveLength(2)
+    const [websocket] = adaptersOfKind('websocket') as InstanceType<
+      typeof FakeWebSocketAdapter
+    >[]
+    expect(websocket.url).toBe('ws://192.168.1.2:9001')
+  })
+
+  // Cross-tab sync must not depend on remote sync being configured.
+  it.each([
+    ['without a sync url', undefined],
+    ['with a sync url', 'ws://192.168.1.2:9001'],
+  ])('always includes the broadcast adapter %s', async (_label, url) => {
+    await renderApp(url)
+
+    expect(adaptersOfKind('broadcast')).toHaveLength(1)
+  })
+
+  it('uses IndexedDB for storage', async () => {
+    await renderApp(undefined)
+
+    expect(repoConfigs[0].storage).toBeInstanceOf(FakeStorageAdapter)
+  })
+})
+
+describe('App initialization guard', () => {
+  // didInitRef exists because initialize() is async and StrictMode double-invokes
+  // effects: without it each run builds its own Repo and its own websocket.
+  it('builds exactly one repo under StrictMode double-invocation', async () => {
+    await renderApp('ws://192.168.1.2:9001', { strict: true })
+
+    expect(repoConfigs).toHaveLength(1)
+    expect(adaptersOfKind('websocket')).toHaveLength(1)
+    expect(adaptersOfKind('broadcast')).toHaveLength(1)
+  })
+
+  it('creates the recordings doc only once under StrictMode', async () => {
+    await renderApp(undefined, { strict: true })
+
+    expect(createCalls).toEqual([{ recordings: [] }])
+  })
+})
+
+describe('App document bootstrap', () => {
+  it('creates a doc and persists its url when none is stored', async () => {
+    await renderApp(undefined)
+
+    expect(createCalls).toEqual([{ recordings: [] }])
+    expect(findCalls).toEqual([])
+    expect(localStorage.getItem('automergeUrl')).toBe(CREATED_URL)
+  })
+
+  it('finds the stored doc instead of creating a new one', async () => {
+    localStorage.setItem('automergeUrl', STORED_URL)
+
+    await renderApp(undefined)
+
+    expect(findCalls).toEqual([STORED_URL])
+    expect(createCalls).toEqual([])
+    expect(localStorage.getItem('automergeUrl')).toBe(STORED_URL)
+  })
+
+  it('creates a fresh doc when the stored url is not a valid automerge url', async () => {
+    localStorage.setItem('automergeUrl', 'not-an-automerge-url')
+
+    await renderApp(undefined)
+
+    expect(findCalls).toEqual([])
+    expect(createCalls).toEqual([{ recordings: [] }])
+    expect(localStorage.getItem('automergeUrl')).toBe(CREATED_URL)
+  })
+
+  it('renders a loading state until the repo is ready', () => {
+    localStorage.setItem('automergeUrl', STORED_URL)
+    control.blockFind = true
+
+    render(<App appContextValue={appContextValue} syncServerUrl={undefined} />)
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+    expect(screen.queryByTestId('providers')).toBeNull()
+  })
+})

--- a/packages/core/app/App.tsx
+++ b/packages/core/app/App.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb'
-// import { BroadcastChannelNetworkAdapter } from '@automerge/automerge-repo-network-broadcastchannel'
+import { BroadcastChannelNetworkAdapter } from '@automerge/automerge-repo-network-broadcastchannel'
 import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
-import { DocHandle, isValidAutomergeUrl, Repo } from '@automerge/automerge-repo'
+import { DocHandle, isValidAutomergeUrl, NetworkAdapterInterface, Repo } from '@automerge/automerge-repo'
 import { Button } from '@tapes-monorepo/ui'
 import {
   useView,
@@ -23,7 +23,7 @@ export function App({
   syncServerUrl,
 }: {
   appContextValue: AppContextValue
-  syncServerUrl: string
+  syncServerUrl?: string | null
 }) {
   const { automergeUrl } = useAutomergeUrl()
   const [repo, setRepo] = useState<Repo | null>(null)
@@ -32,10 +32,6 @@ export function App({
   const didInitRef = useRef(false)
 
   useEffect(() => {
-    // const onEphemeralMessage = (message: any) => {
-    //   console.log('got an ephemeral message: ', message)
-    // }
-
     const initialize = async () => {
       // Guard against re-init (StrictMode double-invoke, dep changes). A `repo`
       // state check can't do this: initialize() is async and setRepo lands only
@@ -45,19 +41,18 @@ export function App({
       }
       didInitRef.current = true
 
-      // const broadcast = new BroadcastChannelNetworkAdapter()
-      // TODO: Set up sync server
-      const websocket = new BrowserWebSocketClientAdapter(
-        // process.env.NODE_ENV === 'development'
-        //   ? `ws://${import.meta.env.VITE_LOCAL_NETWORK_IP}:433`
-        //   : 'wss://sync.automerge.org',
-        syncServerUrl,
-      )
+      // Set up network adapters. 
+      const broadcast = new BroadcastChannelNetworkAdapter()
+      const network: NetworkAdapterInterface[] = [broadcast]
+      if (syncServerUrl) {
+        network.push(new BrowserWebSocketClientAdapter(syncServerUrl))
+      }
+  
       const indexedDB = new IndexedDBStorageAdapter()
 
       const _repo = new Repo({
         storage: indexedDB,
-        network: [websocket],
+        network
       })
 
       if (automergeUrl && isValidAutomergeUrl(automergeUrl)) {
@@ -67,18 +62,10 @@ export function App({
         setAutomergeUrl(handleRef.current.url)
       }
 
-      // handleRef.current.on('ephemeral-message', onEphemeralMessage)
-      // handleRef.current.broadcast({ message: 'Connected to repo' })
-
       setRepo(_repo)
     }
     initialize()
 
-    // return () => {
-    //   if (handleRef.current) {
-    //     handleRef.current.off('ephemeral-message', onEphemeralMessage)
-    //   }
-    // }
   }, [automergeUrl, syncServerUrl])
 
   if (!repo) {
@@ -92,8 +79,8 @@ export function App({
         repoContext: repo,
       }}
     >
-      <Navigation mainRef={mainRef} />
       <Main mainRef={mainRef} />
+      <Navigation mainRef={mainRef} />
       <AudioPlayer />
     </Providers>
   )
@@ -139,7 +126,6 @@ function Main({
 }) {
   const { currentView } = useView()
   const { currentUrl } = useAudioPlayer()
-  // const mainRef = useRef<HTMLDivElement>(null)
 
   return (
     <main

--- a/yarn.lock
+++ b/yarn.lock
@@ -8501,6 +8501,7 @@ __metadata:
     vite-plugin-require: "npm:^1.2.14"
     vite-plugin-top-level-await: "npm:^1.6.0"
     vite-plugin-wasm: "npm:^3.6.0"
+    vitest: "npm:^3.0.0"
     ws: "npm:^8.18.0"
   peerDependencies:
     esbuild-register: "*"


### PR DESCRIPTION
Closes [TAP-64](https://linear.app/tapes/issue/TAP-64/make-sync-optional-in-core-apptsx-and-enable-cross-tab). Part of [TAP-62](https://linear.app/tapes/issue/TAP-62/make-web-client-a-local-first-pwa) (local-first PWA web client).

## Why

`App.tsx` unconditionally built a `BrowserWebSocketClientAdapter` from a required `syncServerUrl: string`. With no sync server on the origin, the `Repo` still boots fine from IndexedDB, but the adapter loops forever on failing reconnects and floods the console. The `BroadcastChannelNetworkAdapter` import was present but commented out, so two tabs of the same origin had no way to see each other's recordings without a server.

## What changed

**`packages/core/app/App.tsx`**

- `syncServerUrl` is now `string | null | undefined` instead of a required `string`.
- The `Repo` network array is built conditionally: the `BroadcastChannelNetworkAdapter` is always included; a `BrowserWebSocketClientAdapter` is appended only when a sync url is actually given.
- Cross-tab sync therefore works regardless of whether remote sync is configured.
- Removed the commented-out ephemeral-message wiring and its cleanup, plus a stale `mainRef` comment.
- `<Main />` now renders before `<Navigation />` in the tree.

The `didInitRef` guard is deliberately untouched — it exists because `initialize()` is async and StrictMode double-invokes the effect, so without it each run would build its own `Repo` and its own websocket. Reconfiguring sync still needs a reload; that's [TAP-58](https://linear.app/tapes/issue/TAP-58/switching-sync-modeurl-triggers-a-page-reload-rather-than-rebuilding), out of scope here.

**Call sites** (the cleanup listed in TAP-64's scope, now included)

- `apps/electron-client/src/renderer.tsx`: dropped the `if (!syncServerUrl) return null` gate. The prop is optional now, so the desktop app renders and works while its embedded sync server is still starting instead of showing a blank window.
- `apps/web-client/src/main.tsx`: the sync url is now derived as `<origin>/sync` in every mode, rather than `/sync` in dev (via the Vite proxy) and a bare origin in a production build. One code path instead of two, and `import.meta.env.DEV` — plus its turbo eslint-disable — is gone. This works because the Electron host attaches its `WebSocketServer` to the whole http server rather than a route, so it accepts the upgrade on any path; `VITE_SYNC_SERVER_URL` still takes precedence for the Vercel deploy. README and `.env.example` updated to match.

## Tests

`packages/core/app/App.test.tsx` (14 tests, merged in via #265) asserts on the `Repo` config `App` actually constructs:

- No sync url → broadcast adapter only, no websocket — parameterised over `undefined`, `null` and `''`.
- With a sync url → both adapters, websocket constructed with that url.
- Broadcast adapter present in both cases; IndexedDB still the storage adapter.
- `didInitRef` regression guard: under `StrictMode`, exactly one `Repo`, one websocket, one broadcast adapter, one doc create.
- Doc bootstrap unchanged: creates and persists a url when none is stored, finds a valid stored url, creates fresh on an invalid one, renders `Loading...` while `find()` is pending.

`apps/electron-client/src/syncServer.test.ts` (new, 2 tests) locks in the assumption the `/sync` change depends on: the embedded sync server accepts a websocket upgrade on both `/sync` and the root path. The electron-client gains a minimal Vitest setup (`vitest.config.ts`, `test` / `test:watch` scripts), and CI's Unit Tests step is extended to `--filter=electron-client` alongside core.

CI on this branch is green: 32 core tests + 2 electron-client tests, plus lint, check-types, build and the web-client e2e suite.

## Acceptance criteria status

| TAP-64 criterion | Status |
| --- | --- |
| No sync url → boots from IndexedDB, records/plays back, no websocket reconnect errors | **Implemented, unit-tested at the wiring level** (no websocket adapter is constructed). Not yet exercised in a running app — see below. |
| Two tabs on the same origin sync via BroadcastChannel with no server | **Implemented**; tests assert the adapter is always in the `Repo` network, but no test drives two real tabs exchanging a doc. |
| With a sync url, Electron-host / LAN-guest sync behaves as before | **Behaviour intentionally changed** (prod web-client now connects to `<origin>/sync` instead of the bare origin). The new `syncServer` test proves the host accepts that path; an actual LAN-guest run is still worth a manual pass. |

### Still needs a manual pass

1. Desktop app: record and play back, then pair a LAN guest over `yarn dev:https` and confirm sync is unchanged.
2. Two browser tabs on the same origin with no sync server running — confirm a recording made in one appears in the other, and that the console has no reconnect spam.

Neither shipped call site currently passes *no* url (the web client always derives `<origin>/sync`; the desktop host always has its embedded server), so the no-sync path is a capability this PR unlocks for the local-first PWA work in TAP-62 rather than a path any build takes today.
