### PR TITLE
refactor(web-client): derive the sync URL as /sync in every mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Build
         run: yarn build
 
-      # Scoped to core: apps/api has its own (Jest) suite with a pre-existing
-      # compile failure unrelated to this gate, so run only the package whose
+      # Explicitly scoped: apps/api has its own (Jest) suite with a pre-existing
+      # compile failure unrelated to this gate, so run only the workspaces whose
       # unit tests this step is meant to guard.
       - name: Unit Tests
-        run: yarn turbo test --filter=@tapes-monorepo/core
+        run: yarn turbo test --filter=@tapes-monorepo/core --filter=electron-client
 
   e2e:
     name: E2E (web-client)

--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -15,6 +15,8 @@
     "publish": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge publish",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "clean": "rm -rf .vite",
     "pull": "vercel env pull .env.local"
   },
@@ -57,7 +59,8 @@
     "vite": "^8.1.5",
     "vite-plugin-require": "^1.2.14",
     "vite-plugin-top-level-await": "^1.6.0",
-    "vite-plugin-wasm": "^3.6.0"
+    "vite-plugin-wasm": "^3.6.0",
+    "vitest": "^3.0.0"
   },
   "peerDependencies": {
     "esbuild-register": "*",

--- a/apps/electron-client/src/syncServer.test.ts
+++ b/apps/electron-client/src/syncServer.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { WebSocket } from 'ws'
+import { afterEach, describe, expect, it } from 'vitest'
+import { startSyncServer, stopSyncServer } from './syncServer'
+
+let storagePath: string | undefined
+
+afterEach(async () => {
+  await stopSyncServer()
+  if (storagePath) {
+    await rm(storagePath, { recursive: true, force: true })
+    storagePath = undefined
+  }
+})
+
+async function startForTest() {
+  storagePath = await mkdtemp(path.join(tmpdir(), 'tapes-sync-'))
+  return startSyncServer({
+    storagePath,
+    host: '127.0.0.1',
+    // 0 lets the OS pick a free port so the suite never collides with a
+    // running desktop app on the default port.
+    port: 0,
+    peerId: 'test-host',
+  })
+}
+
+function connect(url: string) {
+  return new Promise<void>((resolve, reject) => {
+    const socket = new WebSocket(url)
+    socket.on('open', () => {
+      socket.close()
+      resolve()
+    })
+    socket.on('error', reject)
+  })
+}
+
+describe('startSyncServer', () => {
+  // The web client derives its sync URL as `<origin>/sync` in every mode
+  // (see apps/web-client/src/main.tsx): in development Vite proxies that path
+  // here, and in production this server receives it verbatim. That only works
+  // because the WebSocket server is attached to the whole http server rather
+  // than a route, so it must keep accepting the upgrade on a non-root path.
+  it('accepts a sync socket on the /sync path', async () => {
+    const info = await startForTest()
+
+    await expect(connect(`${info.url}/sync`)).resolves.toBeUndefined()
+  })
+
+  it('accepts a sync socket on the root path', async () => {
+    const info = await startForTest()
+
+    await expect(connect(info.url)).resolves.toBeUndefined()
+  })
+})

--- a/apps/electron-client/vitest.config.ts
+++ b/apps/electron-client/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+// Node-environment unit tests for the main-process modules. The `@/` alias
+// mirrors tsconfig.json so imports resolve the same way under test.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/apps/web-client/.env.example
+++ b/apps/web-client/.env.example
@@ -2,7 +2,7 @@
 # See apps/web-client/README.md.
 
 # Optional build-time override for the sync-server URL (e.g. a Vercel deploy).
-# Leave unset to derive the URL from window.location / the /sync dev proxy.
+# Leave unset to derive `<origin>/sync` from window.location.
 VITE_SYNC_SERVER_URL=
 
 # The following are normally set by the dev scripts, not by hand:

--- a/apps/web-client/README.md
+++ b/apps/web-client/README.md
@@ -9,10 +9,11 @@ This same bundle runs in two places:
 - **Standalone** in a browser (e.g. the Vercel-hosted PWA).
 - **Embedded** in the desktop host (`electron-client`) and served to LAN guests.
 
-The sync-server URL is resolved at runtime in `src/main.tsx`: when served by the
-Electron host it's the same origin; in dev it reaches the host's embedded sync
-server through the `/sync` proxy (see `vite.config.ts`); a build-time
-`VITE_SYNC_SERVER_URL` (the Vercel deploy path) takes precedence.
+The sync-server URL is resolved at runtime in `src/main.tsx`: it is always
+`/sync` on the origin serving the bundle. The Electron host accepts the socket
+upgrade on any path, and in dev the Vite dev server proxies `/sync` back to that
+host (see `vite.config.ts`). A build-time `VITE_SYNC_SERVER_URL` (the Vercel
+deploy path) takes precedence.
 
 ## Develop
 

--- a/apps/web-client/src/main.tsx
+++ b/apps/web-client/src/main.tsx
@@ -4,20 +4,16 @@ import { App } from '@tapes-monorepo/core'
 import './index.css'
 import DownloadPrompt from './DownloadPrompt'
 
-// When the bundle is served from the Electron host, the sync server lives on
-// the same origin, so derive the URL from window.location. In development the
-// bundle is instead served by this package's own Vite dev server (for HMR), and
-// the sync socket reaches the host's embedded sync server through the `/sync`
-// proxy (see vite.config.ts). A build-time VITE_SYNC_SERVER_URL (the Vercel
-// deploy path) still takes precedence.
+// The sync socket always lives at `/sync` on the same origin as this bundle.
+// When the Electron host serves the bundle it accepts the upgrade on any path
+// (its WebSocketServer is attached to the whole http server, not a route), and
+// in development the bundle is served by this package's own Vite dev server
+// (for HMR), which proxies `/sync` back to that host (see vite.config.ts). A
+// build-time VITE_SYNC_SERVER_URL (the Vercel deploy path) takes precedence.
 const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
-// `import.meta.env.DEV` is a Vite build-time boolean (dev server vs. static
-// build), not a process env var; the disable is for turbo's env-var lint rule.
-// eslint-disable-next-line turbo/no-undeclared-env-vars
-const servedByDevServer = import.meta.env.DEV
 const syncServerUrl =
   import.meta.env.VITE_SYNC_SERVER_URL ??
-  `${scheme}://${window.location.host}${servedByDevServer ? '/sync' : ''}`
+  `${scheme}://${window.location.host}/sync`
 
 if (!window.Worker) {
   ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8501,6 +8501,7 @@ __metadata:
     vite-plugin-require: "npm:^1.2.14"
     vite-plugin-top-level-await: "npm:^1.6.0"
     vite-plugin-wasm: "npm:^3.6.0"
+    vitest: "npm:^3.0.0"
     ws: "npm:^8.18.0"
   peerDependencies:
     esbuild-register: "*"


### PR DESCRIPTION
## What

`syncServerUrl` in `apps/web-client/src/main.tsx` had a three-way resolution: a build-time `VITE_SYNC_SERVER_URL` override, `<origin>/sync` in development (through the Vite proxy), and bare `<origin>` in production (bundle served by the Electron host).

Branches 2 and 3 differed only in the path. The Electron host builds its socket with `new WebSocketServer({ server })` (`apps/electron-client/src/syncServer.ts`), which attaches to the http server's `upgrade` event regardless of path — the static file handler only ever sees ordinary GETs. So `/sync` works in production too, and the whole thing becomes:

```ts
const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
const syncServerUrl =
  import.meta.env.VITE_SYNC_SERVER_URL ??
  `${scheme}://${window.location.host}/sync`
```

That also drops the `import.meta.env.DEV` read and its `turbo/no-undeclared-env-vars` eslint-disable.

## Why the test

The path-agnostic upgrade was always true but is now load-bearing. `apps/electron-client/src/syncServer.test.ts` starts the real sync server on an OS-assigned port and asserts a `ws` client connects on both `/sync` and the root path. This is electron-client's first unit test, so it brings a small Vitest config with it, and CI's unit-test step gains `--filter=electron-client`.

Verified the test is meaningful: pinning the server to `path: '/'` fails the `/sync` case with a 400 while the root case still passes.

## Checks

`yarn build`, `yarn lint`, `yarn check-types` and `yarn turbo test --filter=@tapes-monorepo/core --filter=electron-client` all pass locally. No changeset — no published package changes behaviour.

Note: running `yarn format` reformats ~20 unrelated files (pre-existing drift, and prettier's markdown parser errors on every `.md` in this environment); none of that churn is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)