### PR TITLE
feat(web-client): explicit sync-URL precedence with local-only fallback (TAP-65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       # compile failure unrelated to this gate, so run only the workspaces whose
       # unit tests this step is meant to guard.
       - name: Unit Tests
-        run: yarn turbo test --filter=@tapes-monorepo/core --filter=electron-client
+        run: yarn turbo test --filter=@tapes-monorepo/core --filter=electron-client --filter=web-client
 
   e2e:
     name: E2E (web-client)

--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -9,7 +9,7 @@
     "get-bin": "tsc downloadExecutables.ts && node downloadExecutables.js",
     "dev": "LOCAL_NETWORK_IP=\"$(ipconfig getifaddr en0)\" WEB_CLIENT_DEV_URL=\"http://$(ipconfig getifaddr en0):3000\" dotenvx run --env-file=.env.local -- electron-forge start -- --trace-warnings",
     "dev:https": "LOCAL_NETWORK_IP=\"$(ipconfig getifaddr en0)\" WEB_CLIENT_DEV_URL=\"https://$(ipconfig getifaddr en0):3000\" dotenvx run --env-file=.env.local -- electron-forge start -- --trace-warnings",
-    "stage-web-client": "yarn workspace web-client build && find web-client -mindepth 1 ! -name .gitkeep -delete && cp -R ../web-client/dist/. web-client/",
+    "stage-web-client": "VITE_SYNC_SERVER_URL= VITE_SERVED_BY_HOST=true yarn workspace web-client build && find web-client -mindepth 1 ! -name .gitkeep -delete && cp -R ../web-client/dist/. web-client/",
     "package": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge package",
     "make": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge make",
     "publish": "yarn stage-web-client && dotenvx run --env-file=.env -- electron-forge publish",

--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -12,6 +12,8 @@
     "lint": "eslint .",
     "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.e2e.json",
     "pull": "vercel env pull .env.local",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui"
   },
@@ -40,6 +42,7 @@
     "typescript": "^6.0.0",
     "vite": "^8.1.5",
     "vite-plugin-top-level-await": "^1.6.0",
-    "vite-plugin-wasm": "^3.6.0"
+    "vite-plugin-wasm": "^3.6.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/apps/web-client/src/main.tsx
+++ b/apps/web-client/src/main.tsx
@@ -3,17 +3,28 @@ import ReactDOM from 'react-dom/client'
 import { App } from '@tapes-monorepo/core'
 import './index.css'
 import DownloadPrompt from './DownloadPrompt'
+import { resolveSyncServerUrl } from './syncServerUrl'
 
-// The sync socket always lives at `/sync` on the same origin as this bundle.
-// When the Electron host serves the bundle it accepts the upgrade on any path
-// (its WebSocketServer is attached to the whole http server, not a route), and
-// in development the bundle is served by this package's own Vite dev server
-// (for HMR), which proxies `/sync` back to that host (see vite.config.ts). A
-// build-time VITE_SYNC_SERVER_URL (the Vercel deploy path) takes precedence.
-const scheme = window.location.protocol === 'https:' ? 'wss' : 'ws'
-const syncServerUrl =
-  import.meta.env.VITE_SYNC_SERVER_URL ??
-  `${scheme}://${window.location.host}/sync`
+// Where this bundle syncs, in precedence order:
+//
+//   1. VITE_SYNC_SERVER_URL — build-time, the Vercel deploy path.
+//   2. `remoteSyncServerUrl` in localStorage — a remote server the user opted
+//      into from Settings.
+//   3. The Vite dev server (import.meta.env.DEV) — same-origin `/sync`, which
+//      the dev server proxies to the Electron host's embedded sync server so a
+//      LAN guest gets HMR and sync at once (see vite.config.ts).
+//   4. VITE_SERVED_BY_HOST — set when electron-client stages this bundle into
+//      its own resources, so the host is serving it and the sync server is on
+//      the same origin. That flag is what distinguishes a host-served bundle
+//      from a standalone static deploy; both are plain builds otherwise.
+//   5. Nothing matched — a standalone deploy with no server to reach. Resolve
+//      to undefined and let core run local-only (IndexedDB plus cross-tab
+//      BroadcastChannel) instead of retrying an origin nothing listens on.
+const syncServerUrl = resolveSyncServerUrl({
+  env: import.meta.env,
+  location: window.location,
+  storage: window.localStorage,
+})
 
 if (!window.Worker) {
   ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/apps/web-client/src/syncServerUrl.test.ts
+++ b/apps/web-client/src/syncServerUrl.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveSyncServerUrl,
+  type SyncUrlEnv,
+  type SyncUrlLocation,
+} from './syncServerUrl'
+
+const HTTP: SyncUrlLocation = { protocol: 'http:', host: 'lan-host:3000' }
+const HTTPS: SyncUrlLocation = { protocol: 'https:', host: 'lan-host:3000' }
+
+function storageWith(settings?: string): Pick<Storage, 'getItem'> {
+  return { getItem: (key) => (key === 'settings' ? (settings ?? null) : null) }
+}
+
+function resolve({
+  env = {},
+  location = HTTP,
+  settings,
+}: {
+  env?: SyncUrlEnv
+  location?: SyncUrlLocation
+  settings?: string
+} = {}) {
+  return resolveSyncServerUrl({
+    env,
+    location,
+    storage: storageWith(settings),
+  })
+}
+
+describe('resolveSyncServerUrl', () => {
+  it('prefers the build-time env var over every other source', () => {
+    expect(
+      resolve({
+        env: { VITE_SYNC_SERVER_URL: 'wss://sync.example.com', DEV: true },
+        settings: JSON.stringify({ remoteSyncServerUrl: 'ws://stored:1234' }),
+      }),
+    ).toBe('wss://sync.example.com')
+  })
+
+  it('falls back to a remote server the user configured in Settings', () => {
+    expect(
+      resolve({
+        settings: JSON.stringify({ remoteSyncServerUrl: 'ws://stored:1234' }),
+      }),
+    ).toBe('ws://stored:1234')
+  })
+
+  it('prefers the stored URL over same-origin /sync', () => {
+    expect(
+      resolve({
+        env: { DEV: true },
+        settings: JSON.stringify({ remoteSyncServerUrl: 'wss://stored:1234' }),
+      }),
+    ).toBe('wss://stored:1234')
+  })
+
+  // A value Automerge could only fail to connect to must not win the chain.
+  it.each([
+    ['a non-websocket protocol', JSON.stringify({ remoteSyncServerUrl: 'https://nope' })],
+    ['an unparseable URL', JSON.stringify({ remoteSyncServerUrl: 'not a url' })],
+    ['a non-string value', JSON.stringify({ remoteSyncServerUrl: 1234 })],
+    ['an absent key', JSON.stringify({ audioFormat: 'wav' })],
+    ['malformed settings JSON', '{ not json'],
+    ['a non-object settings blob', '"just a string"'],
+  ])('ignores a stored URL with %s', (_case, settings) => {
+    expect(resolve({ settings })).toBeUndefined()
+    // ...and still falls through to the next rung rather than short-circuiting.
+    expect(resolve({ env: { DEV: true }, settings })).toBe(
+      'ws://lan-host:3000/sync',
+    )
+  })
+
+  it('uses same-origin /sync when served by the dev server', () => {
+    expect(resolve({ env: { DEV: true } })).toBe('ws://lan-host:3000/sync')
+  })
+
+  it('uses same-origin /sync when the Electron host serves the bundle', () => {
+    expect(resolve({ env: { VITE_SERVED_BY_HOST: 'true' } })).toBe(
+      'ws://lan-host:3000/sync',
+    )
+  })
+
+  it('upgrades the scheme to wss on an https origin', () => {
+    expect(resolve({ env: { DEV: true }, location: HTTPS })).toBe(
+      'wss://lan-host:3000/sync',
+    )
+    expect(
+      resolve({ env: { VITE_SERVED_BY_HOST: 'true' }, location: HTTPS }),
+    ).toBe('wss://lan-host:3000/sync')
+  })
+
+  it('runs local-only for a standalone static deploy', () => {
+    expect(resolve()).toBeUndefined()
+  })
+
+  it('treats a host flag that is not "true" as standalone', () => {
+    expect(resolve({ env: { VITE_SERVED_BY_HOST: 'false' } })).toBeUndefined()
+  })
+})

--- a/apps/web-client/src/syncServerUrl.ts
+++ b/apps/web-client/src/syncServerUrl.ts
@@ -1,0 +1,94 @@
+/**
+ * Resolves the Automerge sync server URL for this bundle, or `undefined` to run
+ * local-only. The precedence chain is documented in `main.tsx`, which is the
+ * only caller; everything here takes its inputs as arguments so the chain can
+ * be exercised in tests without a browser or a running Electron host.
+ */
+
+export type SyncUrlEnv = {
+  VITE_SYNC_SERVER_URL?: string
+  VITE_SERVED_BY_HOST?: string
+  DEV?: boolean
+}
+
+export type SyncUrlLocation = {
+  protocol: string
+  host: string
+}
+
+export function resolveSyncServerUrl({
+  env,
+  location,
+  storage,
+}: {
+  env: SyncUrlEnv
+  location: SyncUrlLocation
+  storage: Pick<Storage, 'getItem'>
+}): string | undefined {
+  // 1. Build-time env var: the Vercel deploy path.
+  if (env.VITE_SYNC_SERVER_URL) {
+    return env.VITE_SYNC_SERVER_URL
+  }
+
+  // 2. A remote server the user opted into from Settings. Unlike the Electron
+  // renderer this ignores `syncServerMode`: there is no embedded server in a
+  // browser, so a stored URL means "sync with this" and clearing it means
+  // "local-only".
+  const remoteSyncServerUrl = readRemoteSyncServerUrl(storage)
+  if (remoteSyncServerUrl) {
+    return remoteSyncServerUrl
+  }
+
+  // 3 & 4. Same-origin `/sync`. In development that is web-client's own Vite
+  // dev server proxying back to the host's embedded sync server (see
+  // vite.config.ts); in a staged build it is the Electron host itself, whose
+  // WebSocketServer is attached to the whole http server rather than a route,
+  // so it accepts the upgrade on `/sync` too.
+  if (env.DEV || env.VITE_SERVED_BY_HOST === 'true') {
+    const scheme = location.protocol === 'https:' ? 'wss' : 'ws'
+    return `${scheme}://${location.host}/sync`
+  }
+
+  // 5. A standalone static deploy has nothing to sync with.
+  return undefined
+}
+
+/**
+ * Reads `remoteSyncServerUrl` out of the settings blob core's SettingsProvider
+ * writes to localStorage, mirroring the pre-mount read in the Electron
+ * renderer. Anything unusable — absent key, malformed JSON, a URL that is not
+ * `ws:`/`wss:` — resolves to undefined so the caller falls through rather than
+ * handing Automerge an address that can only produce reconnect noise.
+ */
+function readRemoteSyncServerUrl(
+  storage: Pick<Storage, 'getItem'>,
+): string | undefined {
+  let settings: unknown
+  try {
+    settings = JSON.parse(storage.getItem('settings') ?? '{}')
+  } catch {
+    return undefined
+  }
+
+  if (typeof settings !== 'object' || settings === null) {
+    return undefined
+  }
+
+  const { remoteSyncServerUrl } = settings as {
+    remoteSyncServerUrl?: unknown
+  }
+
+  if (typeof remoteSyncServerUrl !== 'string') {
+    return undefined
+  }
+
+  // The same validation the Settings UI applies before storing a value.
+  try {
+    const { protocol } = new URL(remoteSyncServerUrl)
+    return protocol === 'ws:' || protocol === 'wss:'
+      ? remoteSyncServerUrl
+      : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/apps/web-client/src/vite-env.d.ts
+++ b/apps/web-client/src/vite-env.d.ts
@@ -2,6 +2,12 @@
 
 interface ImportMetaEnv {
   readonly VITE_SYNC_SERVER_URL?: string
+  // Set by electron-client's `stage-web-client` script: marks a bundle the
+  // Electron host serves itself, as opposed to a standalone static deploy.
+  // That script also blanks VITE_SYNC_SERVER_URL, because a developer's
+  // `.env.local` would otherwise be inlined into the staged bundle and outrank
+  // the host's own origin.
+  readonly VITE_SERVED_BY_HOST?: string
 }
 
 interface ImportMeta {

--- a/apps/web-client/vitest.config.ts
+++ b/apps/web-client/vitest.config.ts
@@ -1,0 +1,17 @@
+import path from 'path'
+import { defineConfig } from 'vitest/config'
+
+// Node-environment unit tests for the browser-independent modules. The `@/`
+// alias mirrors vite.config.ts so imports resolve the same way under test.
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,12 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
-  "globalEnv": ["NODE_ENV", "WEB_CLIENT_DEV_URL"],
+  "globalEnv": [
+    "NODE_ENV",
+    "WEB_CLIENT_DEV_URL",
+    "VITE_SERVED_BY_HOST",
+    "VITE_SYNC_SERVER_URL"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -17568,6 +17568,7 @@ __metadata:
     vite: "npm:^8.1.5"
     vite-plugin-top-level-await: "npm:^1.6.0"
     vite-plugin-wasm: "npm:^3.6.0"
+    vitest: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Closes [TAP-65](https://linear.app/tapes/issue/TAP-65/give-web-client-an-explicit-sync-url-precedence-chain-with-a-local).

## Problem

`main.tsx` always resolved to *some* sync URL — with no `VITE_SYNC_SERVER_URL` it fell back to same-origin `/sync`. A standalone static deploy therefore pointed its Automerge websocket at an origin where nothing listens and retried forever. There was no way to express "no sync".

## Precedence chain

1. `VITE_SYNC_SERVER_URL` — build-time, the Vercel deploy path
2. `remoteSyncServerUrl` in localStorage — a remote server the user opted into from Settings
3. Vite dev server (`import.meta.env.DEV`) → same-origin `/sync` (proxied to the host's embedded server)
4. `VITE_SERVED_BY_HOST` → same-origin `/sync` (the Electron host is serving this bundle)
5. otherwise `undefined` → local-only

Core has accepted an absent URL since TAP-64 (#264), so step 5 means IndexedDB plus the cross-tab BroadcastChannel adapter and no socket at all.

## Notes for review

- **Host detection is a build-time flag.** Host-served and standalone bundles are otherwise identical builds, so `stage-web-client` marks its copy with `VITE_SERVED_BY_HOST=true`. Chosen over a runtime probe (async, and static hosts SPA-fallback with a 200 so it needs a content-type guard) and over HTML injection (`syncServer.ts` streams raw bytes, and the dev path bypasses Electron entirely).
- **Steps 3 and 4 both resolve to `/sync`.** #266 unified on that path, and the host's `WebSocketServer` is attached to the whole http server with no path filter (`syncServer.ts:220`), so it upgrades there too. The flag only distinguishes sync from local-only.
- **`stage-web-client` also blanks `VITE_SYNC_SERVER_URL`.** Verified empirically: a developer's `.env.local` is inlined into the staged bundle and, as step 1, would outrank the host's own origin — packaged guests would sync with the remote server instead of the app that served them. `process.env` overrides `.env.local`, and an empty value is falsy, so it falls through to step 4.
- **`syncServerMode` is deliberately ignored**, unlike `renderer.tsx`. There is no embedded server in a browser, so a stored URL means "sync with this" and clearing it means local-only — the contract TAP-68's settings UI will build on. A stored value that is absent, malformed, or not `ws:`/`wss:` falls through rather than producing the reconnect noise this change removes.
- `playwright.config.ts:63` still injects `VITE_SYNC_SERVER_URL` with a comment saying `main.tsx` throws without it — no longer true, and droppable in a follow-up. Left alone here.

## Verification

- `yarn build`, `yarn lint`, `yarn check-types` — all green (the one lint warning is pre-existing on `main`).
- `yarn turbo test` across core / electron-client / web-client — 48 passing, 14 of them new, covering every rung and fall-through.
- Existing web-client e2e suite — 6 passing, no regression.
- **Standalone build in a real browser** (`vite preview`, no env var, no stored setting, phone-width viewport): zero websockets opened, no console errors, app booted to the full recorder UI, and two tabs converged on the same Automerge doc — local-only works and cross-tab sync is intact.

Not verified headlessly, needs a device: the LAN-guest HMR flow (step 3) and a phone loading the staged bundle from a running host (step 4). Both paths resolve to the same `/sync` URL the current code already uses, and the staged bundle's inlined env was checked directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)