### PR TITLE
feat(electron-client): store data on the filesystem via the embedded sync server (TAP-69)

### DIFF
--- a/.changeset/tap-69-electron-fs-storage.md
+++ b/.changeset/tap-69-electron-fs-storage.md
@@ -1,0 +1,5 @@
+---
+'@tapes-monorepo/core': minor
+---
+
+`App` no longer builds the Automerge `Repo`. Each shell now constructs its own and passes it in as `repoContextValue` (`null` while bootstrapping), because storage and network adapters are platform-specific: the web client persists to IndexedDB, while the electron renderer runs without a storage adapter and lets its embedded sync server persist to the filesystem. The `syncServerUrl` prop is gone — nothing in core used it once the repo moved out.

--- a/apps/electron-client/package.json
+++ b/apps/electron-client/package.json
@@ -84,6 +84,7 @@
     "@automerge/automerge": "^3.0.0",
     "@automerge/automerge-repo": "^2.0.0",
     "@automerge/automerge-repo-network-websocket": "^2.0.0",
+    "@automerge/automerge-repo-storage-indexeddb": "^2.0.0",
     "@automerge/automerge-repo-storage-nodefs": "^2.0.0",
     "@dotenvx/dotenvx": "^2.0.0",
     "@tapes-monorepo/core": "*",

--- a/apps/electron-client/src/renderer.tsx
+++ b/apps/electron-client/src/renderer.tsx
@@ -3,7 +3,6 @@ import { createRoot } from 'react-dom/client'
 import {
   App,
   IpcService,
-  RecordingRepoState,
   SyncServerInfo,
   useAutomergeUrl,
 } from '@tapes-monorepo/core'
@@ -11,7 +10,7 @@ import './index.css'
 import { DocHandle, isValidAutomergeUrl, Repo } from '@automerge/automerge-repo'
 import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb'
 import {
-  buildRendererNetwork,
+  bootstrapRendererRepo,
   readSyncSettings,
   resolveSyncServerUrls,
   type SyncServerUrls,
@@ -26,9 +25,6 @@ const appContextValue = {
   type: 'electron-client' as const,
   ipc: new IpcService(),
 }
-
-/** How long to wait for a peer to answer with the stored library. */
-const FIND_TIMEOUT_MS = 10_000
 
 function ElectronAppRoot() {
   const { automergeUrl, setAutomergeUrl } = useAutomergeUrl()
@@ -81,79 +77,27 @@ function ElectronAppRoot() {
       }
       didInitRef.current = true
 
-      const storedUrl =
-        automergeUrl && isValidAutomergeUrl(automergeUrl) ? automergeUrl : null
-
-      // Finds the stored library in `candidate`, or creates a fresh one when
-      // there is nothing stored yet. Reports whether the library was found, so
-      // the caller can try a different repo rather than inventing a new doc.
-      const bootstrap = async (candidate: Repo) => {
-        if (!storedUrl) {
-          handleRef.current = candidate.create<RecordingRepoState>({
-            recordings: [],
-          })
-          setAutomergeUrl(handleRef.current.url)
-          setRepo(candidate)
-          return true
-        }
-
-        try {
-          // A peer that never answers would otherwise leave `find` pending
-          // forever: the websocket adapter reports itself ready a second after
-          // construction whether or not it ever connected.
-          handleRef.current = await candidate.find(storedUrl, {
-            signal: AbortSignal.timeout(FIND_TIMEOUT_MS),
-          })
-          setRepo(candidate)
-          return true
-        } catch (findError) {
-          console.info('Library not found in this repo', findError)
-          return false
-        }
-      }
-
-      // Without a running embedded server there is nothing to persist to on
-      // disk, so keep the legacy IndexedDB store rather than running the session
-      // with no persistence at all.
-      if (!syncServerUrls.localUrl) {
-        const offlineRepo = new Repo({
-          storage: new IndexedDBStorageAdapter(),
-          network: buildRendererNetwork(syncServerUrls),
-        })
-        if (!(await bootstrap(offlineRepo))) {
-          setError('Your library could not be loaded from this device.')
-        }
-        return
-      }
-
-      // No storage adapter: the embedded sync server persists these documents
-      // to the filesystem for us (see syncServer.ts), which keeps the desktop
-      // library off the renderer's origin quota. It responds to requests even
-      // though its share policy never announces, so `find` works.
-      const _repo = new Repo({
-        network: buildRendererNetwork(syncServerUrls),
+      const result = await bootstrapRendererRepo({
+        storedUrl:
+          automergeUrl && isValidAutomergeUrl(automergeUrl)
+            ? automergeUrl
+            : null,
+        urls: syncServerUrls,
+        createStorage: () => new IndexedDBStorageAdapter(),
       })
 
-      if (await bootstrap(_repo)) {
-        return
-      }
-
-      // The server doesn't have the library. That's a pre-TAP-69 install, whose
-      // only copy is in this renderer's IndexedDB: run this session on the
-      // legacy IndexedDB-backed repo, which announces the library to the server
-      // in the background so the next launch finds it on disk. Once this has
-      // shipped for a release, the fallback and the IndexedDB dependency can go.
-      await _repo.shutdown()
-      const legacyRepo = new Repo({
-        storage: new IndexedDBStorageAdapter(),
-        network: buildRendererNetwork(syncServerUrls),
-      })
-
-      if (!(await bootstrap(legacyRepo))) {
-        // Neither the server nor IndexedDB has it. Creating a fresh doc here
-        // would be indistinguishable from silently losing the library.
+      if (result.status === 'unavailable') {
+        // Creating a fresh doc here would be indistinguishable from silently
+        // losing the library.
         setError('Your library could not be loaded from this device.')
+        return
       }
+
+      handleRef.current = result.handle
+      if (result.createdUrl) {
+        setAutomergeUrl(result.createdUrl)
+      }
+      setRepo(result.repo)
     }
     initialize()
   }, [automergeUrl, setAutomergeUrl, syncServerUrls])

--- a/apps/electron-client/src/renderer.tsx
+++ b/apps/electron-client/src/renderer.tsx
@@ -1,7 +1,21 @@
-import { StrictMode, useEffect, useState } from 'react'
+import { StrictMode, useEffect, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
-import { App, IpcService, SyncServerInfo } from '@tapes-monorepo/core'
+import {
+  App,
+  IpcService,
+  RecordingRepoState,
+  SyncServerInfo,
+  useAutomergeUrl,
+} from '@tapes-monorepo/core'
 import './index.css'
+import { DocHandle, isValidAutomergeUrl, Repo } from '@automerge/automerge-repo'
+import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb'
+import {
+  buildRendererNetwork,
+  readSyncSettings,
+  resolveSyncServerUrls,
+  type SyncServerUrls,
+} from './rendererRepo'
 
 const rootElement = document.getElementById('root')
 if (!rootElement) {
@@ -13,46 +27,146 @@ const appContextValue = {
   ipc: new IpcService(),
 }
 
-function getRemoteSyncServerUrl(): string | undefined {
-  // Settings are written by core's SettingsProvider under this key.
-  const settings = JSON.parse(localStorage.getItem('settings') ?? '{}') as {
-    syncServerMode?: string
-    remoteSyncServerUrl?: string
-  }
-
-  const remoteUrl =
-    settings.remoteSyncServerUrl ?? import.meta.env.VITE_SYNC_SERVER_URL
-
-  return settings.syncServerMode === 'remote' ? remoteUrl : undefined
-}
+/** How long to wait for a peer to answer with the stored library. */
+const FIND_TIMEOUT_MS = 10_000
 
 function ElectronAppRoot() {
-  const [syncServerUrl, setSyncServerUrl] = useState<string | null>(
-    () => getRemoteSyncServerUrl() ?? null,
+  const { automergeUrl, setAutomergeUrl } = useAutomergeUrl()
+
+  const [syncServerUrls, setSyncServerUrls] = useState<SyncServerUrls | null>(
+    null,
   )
+  const [repo, setRepo] = useState<Repo | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const handleRef = useRef<DocHandle<unknown> | null>(null)
+  const didInitRef = useRef(false)
 
+  // The embedded server's url only arrives over IPC, and the repo must be built
+  // with its adapters already in place: `Repo.find` waits for the network to be
+  // ready and then requests the doc, so a repo built before the url resolves
+  // would have no peer to ask and report the library as unavailable.
   useEffect(() => {
-    if (syncServerUrl) {
-      return
-    }
-
     appContextValue.ipc
       .send<SyncServerInfo>('sync:get-server-info')
       .then((info) => {
-        if (info.running) {
-          setSyncServerUrl(info.url)
-          return
+        const urls = resolveSyncServerUrls({
+          settings: readSyncSettings(localStorage),
+          serverInfo: info,
+          envSyncServerUrl: import.meta.env.VITE_SYNC_SERVER_URL,
+        })
+        if (!urls.localUrl) {
+          console.error(
+            'Embedded sync server is not running: recordings made in this session will not be stored on disk',
+          )
         }
-        const fallbackUrl = import.meta.env.VITE_SYNC_SERVER_URL
-        if (fallbackUrl) {
-          setSyncServerUrl(fallbackUrl)
-          return
-        }
-        console.error('Embedded sync server is not running')
+        setSyncServerUrls(urls)
       })
-  }, [syncServerUrl])
+      .catch((ipcError) => {
+        console.error('Failed to reach the embedded sync server', ipcError)
+        setError('Could not reach the local sync server.')
+      })
+  }, [])
 
-  return <App appContextValue={appContextValue} syncServerUrl={syncServerUrl} />
+  useEffect(() => {
+    if (!syncServerUrls) {
+      return
+    }
+
+    const initialize = async () => {
+      // Guard against re-init (StrictMode double-invoke, dep changes). A `repo`
+      // state check can't do this: initialize() is async and setRepo lands only
+      // at the end, so concurrent runs would each build a Repo and websocket.
+      if (didInitRef.current) {
+        return
+      }
+      didInitRef.current = true
+
+      const storedUrl =
+        automergeUrl && isValidAutomergeUrl(automergeUrl) ? automergeUrl : null
+
+      // Finds the stored library in `candidate`, or creates a fresh one when
+      // there is nothing stored yet. Reports whether the library was found, so
+      // the caller can try a different repo rather than inventing a new doc.
+      const bootstrap = async (candidate: Repo) => {
+        if (!storedUrl) {
+          handleRef.current = candidate.create<RecordingRepoState>({
+            recordings: [],
+          })
+          setAutomergeUrl(handleRef.current.url)
+          setRepo(candidate)
+          return true
+        }
+
+        try {
+          // A peer that never answers would otherwise leave `find` pending
+          // forever: the websocket adapter reports itself ready a second after
+          // construction whether or not it ever connected.
+          handleRef.current = await candidate.find(storedUrl, {
+            signal: AbortSignal.timeout(FIND_TIMEOUT_MS),
+          })
+          setRepo(candidate)
+          return true
+        } catch (findError) {
+          console.info('Library not found in this repo', findError)
+          return false
+        }
+      }
+
+      // Without a running embedded server there is nothing to persist to on
+      // disk, so keep the legacy IndexedDB store rather than running the session
+      // with no persistence at all.
+      if (!syncServerUrls.localUrl) {
+        const offlineRepo = new Repo({
+          storage: new IndexedDBStorageAdapter(),
+          network: buildRendererNetwork(syncServerUrls),
+        })
+        if (!(await bootstrap(offlineRepo))) {
+          setError('Your library could not be loaded from this device.')
+        }
+        return
+      }
+
+      // No storage adapter: the embedded sync server persists these documents
+      // to the filesystem for us (see syncServer.ts), which keeps the desktop
+      // library off the renderer's origin quota. It responds to requests even
+      // though its share policy never announces, so `find` works.
+      const _repo = new Repo({
+        network: buildRendererNetwork(syncServerUrls),
+      })
+
+      if (await bootstrap(_repo)) {
+        return
+      }
+
+      // The server doesn't have the library. That's a pre-TAP-69 install, whose
+      // only copy is in this renderer's IndexedDB: run this session on the
+      // legacy IndexedDB-backed repo, which announces the library to the server
+      // in the background so the next launch finds it on disk. Once this has
+      // shipped for a release, the fallback and the IndexedDB dependency can go.
+      await _repo.shutdown()
+      const legacyRepo = new Repo({
+        storage: new IndexedDBStorageAdapter(),
+        network: buildRendererNetwork(syncServerUrls),
+      })
+
+      if (!(await bootstrap(legacyRepo))) {
+        // Neither the server nor IndexedDB has it. Creating a fresh doc here
+        // would be indistinguishable from silently losing the library.
+        setError('Your library could not be loaded from this device.')
+      }
+    }
+    initialize()
+  }, [automergeUrl, setAutomergeUrl, syncServerUrls])
+
+  if (error) {
+    return <div>{error}</div>
+  }
+
+  if (!repo) {
+    return <div>Loading...</div>
+  }
+
+  return <App appContextValue={appContextValue} repoContextValue={repo} />
 }
 
 const root = createRoot(rootElement)

--- a/apps/electron-client/src/rendererRepo.test.ts
+++ b/apps/electron-client/src/rendererRepo.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { SyncServerInfo } from '@tapes-monorepo/core'
+import {
+  buildRendererNetwork,
+  readSyncSettings,
+  resolveSyncServerUrls,
+} from './rendererRepo'
+
+// buildRendererNetwork is asserted through the urls it is given: constructing a
+// BrowserWebSocketClientAdapter here would open real sockets.
+vi.mock('@automerge/automerge-repo-network-websocket', () => ({
+  BrowserWebSocketClientAdapter: class {
+    constructor(public url: string) {}
+  },
+}))
+
+const runningServer: SyncServerInfo = {
+  running: true,
+  url: 'ws://127.0.0.1:9001',
+  port: 9001,
+  host: '127.0.0.1',
+}
+
+const stoppedServer: SyncServerInfo = {
+  running: false,
+  url: '',
+  port: 0,
+  host: '',
+}
+
+describe('resolveSyncServerUrls', () => {
+  it('uses the embedded server when it is running', () => {
+    expect(
+      resolveSyncServerUrls({ settings: {}, serverInfo: runningServer }),
+    ).toEqual({ localUrl: 'ws://127.0.0.1:9001', remoteUrl: undefined })
+  })
+
+  // The renderer holds no storage of its own, so dropping the local url in
+  // remote mode would mean nothing persists to disk that session.
+  it('keeps the embedded server alongside a remote one in remote mode', () => {
+    expect(
+      resolveSyncServerUrls({
+        settings: {
+          syncServerMode: 'remote',
+          remoteSyncServerUrl: 'wss://sync.example.com',
+        },
+        serverInfo: runningServer,
+      }),
+    ).toEqual({
+      localUrl: 'ws://127.0.0.1:9001',
+      remoteUrl: 'wss://sync.example.com',
+    })
+  })
+
+  it('ignores a configured remote url when not in remote mode', () => {
+    expect(
+      resolveSyncServerUrls({
+        settings: { remoteSyncServerUrl: 'wss://sync.example.com' },
+        serverInfo: runningServer,
+      }).remoteUrl,
+    ).toBeUndefined()
+  })
+
+  it('falls back to the build-time url in remote mode with none configured', () => {
+    expect(
+      resolveSyncServerUrls({
+        settings: { syncServerMode: 'remote' },
+        serverInfo: runningServer,
+        envSyncServerUrl: 'wss://build-time.example.com',
+      }).remoteUrl,
+    ).toBe('wss://build-time.example.com')
+  })
+
+  // Without the embedded server nothing persists locally, but syncing to the
+  // build-time server still beats having no peer at all.
+  it('falls back to the build-time url when the embedded server is down', () => {
+    expect(
+      resolveSyncServerUrls({
+        settings: {},
+        serverInfo: stoppedServer,
+        envSyncServerUrl: 'wss://build-time.example.com',
+      }),
+    ).toEqual({ remoteUrl: 'wss://build-time.example.com' })
+  })
+
+  it('resolves no urls when there is no server anywhere', () => {
+    expect(
+      resolveSyncServerUrls({ settings: {}, serverInfo: stoppedServer }),
+    ).toEqual({ localUrl: undefined, remoteUrl: undefined })
+  })
+
+  it('resolves no urls when the server info never arrived', () => {
+    expect(
+      resolveSyncServerUrls({ settings: {}, serverInfo: undefined }),
+    ).toEqual({ localUrl: undefined, remoteUrl: undefined })
+  })
+})
+
+describe('readSyncSettings', () => {
+  it('reads the settings blob core writes', () => {
+    const storage = {
+      getItem: () => JSON.stringify({ syncServerMode: 'remote' }),
+    }
+
+    expect(readSyncSettings(storage)).toEqual({ syncServerMode: 'remote' })
+  })
+
+  it.each([
+    ['missing', null],
+    ['corrupt', '{not json'],
+    ['not an object', 'null'],
+  ])('falls back to empty settings when the blob is %s', (_label, stored) => {
+    const storage = { getItem: () => stored }
+
+    expect(readSyncSettings(storage)).toEqual({})
+  })
+
+  it('keeps a websocket remote url', () => {
+    const storage = {
+      getItem: () =>
+        JSON.stringify({ remoteSyncServerUrl: 'wss://sync.example.com' }),
+    }
+
+    expect(readSyncSettings(storage).remoteSyncServerUrl).toBe(
+      'wss://sync.example.com',
+    )
+  })
+
+  // A stored value Automerge could only produce reconnect noise from is dropped,
+  // so resolveSyncServerUrls falls through to the build-time url instead.
+  it.each([
+    ['the wrong protocol', 'https://sync.example.com'],
+    ['not a url at all', 'sync.example.com'],
+    ['not a string', 42],
+  ])('drops a remote url that is %s', (_label, stored) => {
+    const storage = {
+      getItem: () => JSON.stringify({ remoteSyncServerUrl: stored }),
+    }
+
+    expect(readSyncSettings(storage).remoteSyncServerUrl).toBeUndefined()
+  })
+
+  it('drops a syncServerMode that is not a string', () => {
+    const storage = { getItem: () => JSON.stringify({ syncServerMode: 1 }) }
+
+    expect(readSyncSettings(storage).syncServerMode).toBeUndefined()
+  })
+})
+
+describe('buildRendererNetwork', () => {
+  it('builds one adapter per resolved url, local first', () => {
+    const network = buildRendererNetwork({
+      localUrl: 'ws://127.0.0.1:9001',
+      remoteUrl: 'wss://sync.example.com',
+    })
+
+    expect(
+      network.map((adapter) => (adapter as unknown as { url: string }).url),
+    ).toEqual(['ws://127.0.0.1:9001', 'wss://sync.example.com'])
+  })
+
+  it('builds no adapters when no url resolved', () => {
+    expect(buildRendererNetwork({})).toEqual([])
+  })
+})

--- a/apps/electron-client/src/rendererRepo.ts
+++ b/apps/electron-client/src/rendererRepo.ts
@@ -1,6 +1,12 @@
-import type { NetworkAdapterInterface } from '@automerge/automerge-repo'
+import {
+  Repo,
+  type AutomergeUrl,
+  type DocHandle,
+  type NetworkAdapterInterface,
+  type StorageAdapterInterface,
+} from '@automerge/automerge-repo'
 import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
-import type { SyncServerInfo } from '@tapes-monorepo/core'
+import type { RecordingRepoState, SyncServerInfo } from '@tapes-monorepo/core'
 
 /**
  * Where the renderer's repo syncs. The renderer holds no storage of its own —
@@ -102,4 +108,95 @@ export function buildRendererNetwork({
   return [localUrl, remoteUrl]
     .filter((url): url is string => Boolean(url))
     .map((url) => new BrowserWebSocketClientAdapter(url))
+}
+
+/** How long to wait for a peer to answer with the stored library. */
+export const DEFAULT_FIND_TIMEOUT_MS = 10_000
+
+export type RendererRepoBootstrap =
+  | {
+      status: 'ready'
+      repo: Repo
+      handle: DocHandle<unknown>
+      /** Set only when a new library was created, for the caller to persist. */
+      createdUrl?: AutomergeUrl
+    }
+  /** A library url is stored, but no repo we can reach holds that document. */
+  | { status: 'unavailable' }
+
+/**
+ * Builds the repo the renderer runs on, and loads (or creates) the library in
+ * it.
+ *
+ * The embedded sync server owns persistence — its `NodeFSStorageAdapter` is the
+ * disk of record — so the repo normally carries no storage adapter of its own,
+ * keeping the desktop library off the renderer's origin quota. Two cases still
+ * need the browser-side store, which the caller supplies via `createStorage`:
+ * no embedded server (nothing to persist to), and a pre-TAP-69 library the
+ * server has never seen.
+ */
+export async function bootstrapRendererRepo({
+  storedUrl,
+  urls,
+  createStorage,
+  createNetwork = buildRendererNetwork,
+  findTimeoutMs = DEFAULT_FIND_TIMEOUT_MS,
+}: {
+  storedUrl: AutomergeUrl | null
+  urls: SyncServerUrls
+  createStorage: () => StorageAdapterInterface
+  createNetwork?: (urls: SyncServerUrls) => NetworkAdapterInterface[]
+  findTimeoutMs?: number
+}): Promise<RendererRepoBootstrap> {
+  // Finds the stored library in `candidate`, or creates a fresh one when there
+  // is nothing stored yet. Reports failure so the caller can try a different
+  // repo rather than inventing a new document.
+  const load = async (candidate: Repo): Promise<RendererRepoBootstrap> => {
+    if (!storedUrl) {
+      const handle = candidate.create<RecordingRepoState>({ recordings: [] })
+      return {
+        status: 'ready',
+        repo: candidate,
+        handle,
+        createdUrl: handle.url,
+      }
+    }
+
+    try {
+      // A peer that never answers would otherwise leave `find` pending forever:
+      // the websocket adapter reports itself ready a second after construction
+      // whether or not it ever connected.
+      const handle = await candidate.find(storedUrl, {
+        signal: AbortSignal.timeout(findTimeoutMs),
+      })
+      return { status: 'ready', repo: candidate, handle }
+    } catch (error) {
+      console.info('Library not found in this repo', error)
+      return { status: 'unavailable' }
+    }
+  }
+
+  // Without a running embedded server there is nothing to persist to on disk,
+  // so keep the browser-side store rather than running with no persistence.
+  if (!urls.localUrl) {
+    return load(
+      new Repo({ storage: createStorage(), network: createNetwork(urls) }),
+    )
+  }
+
+  const repo = new Repo({ network: createNetwork(urls) })
+  const result = await load(repo)
+  if (result.status === 'ready') {
+    return result
+  }
+
+  // The server doesn't have the library. That's a pre-TAP-69 install, whose only
+  // copy is in the renderer's own storage: run this session on the legacy
+  // store-backed repo, which announces the library to the server so the next
+  // launch finds it on disk. Once this has shipped for a release, the fallback
+  // and the IndexedDB dependency can go.
+  await repo.shutdown()
+  return load(
+    new Repo({ storage: createStorage(), network: createNetwork(urls) }),
+  )
 }

--- a/apps/electron-client/src/rendererRepo.ts
+++ b/apps/electron-client/src/rendererRepo.ts
@@ -1,0 +1,105 @@
+import type { NetworkAdapterInterface } from '@automerge/automerge-repo'
+import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
+import type { SyncServerInfo } from '@tapes-monorepo/core'
+
+/**
+ * Where the renderer's repo syncs. The renderer holds no storage of its own —
+ * the embedded sync server's `NodeFSStorageAdapter` is the disk of record (see
+ * syncServer.ts) — so `localUrl` is what makes anything persist at all, and it
+ * is kept even when the user has opted into a remote server.
+ */
+export type SyncServerUrls = {
+  /** The embedded sync server, i.e. this app's own on-disk store. */
+  localUrl?: string
+  /** A remote server the user opted into, synced to in addition to the local one. */
+  remoteUrl?: string
+}
+
+/** The subset of core's settings blob that decides where we sync. */
+type SyncSettings = {
+  syncServerMode?: string
+  remoteSyncServerUrl?: string
+}
+
+/**
+ * Reads the sync-relevant fields out of the settings blob core's
+ * SettingsProvider writes to localStorage. Anything unusable — malformed JSON,
+ * a non-object, a URL that is not `ws:`/`wss:` — is dropped rather than passed
+ * on, so a bad stored value falls through to the next candidate instead of
+ * handing Automerge an address that can only produce reconnect noise. Mirrors
+ * `readRemoteSyncServerUrl` in web-client's syncServerUrl.ts.
+ */
+export function readSyncSettings(
+  storage: Pick<Storage, 'getItem'>,
+): SyncSettings {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(storage.getItem('settings') ?? '{}')
+  } catch {
+    return {}
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    return {}
+  }
+
+  const { syncServerMode, remoteSyncServerUrl } = parsed as {
+    syncServerMode?: unknown
+    remoteSyncServerUrl?: unknown
+  }
+
+  return {
+    syncServerMode:
+      typeof syncServerMode === 'string' ? syncServerMode : undefined,
+    remoteSyncServerUrl: isSyncServerUrl(remoteSyncServerUrl)
+      ? remoteSyncServerUrl
+      : undefined,
+  }
+}
+
+/** The same validation the Settings UI applies before storing a value. */
+function isSyncServerUrl(value: unknown): value is string {
+  if (typeof value !== 'string') {
+    return false
+  }
+  try {
+    const { protocol } = new URL(value)
+    return protocol === 'ws:' || protocol === 'wss:'
+  } catch {
+    return false
+  }
+}
+
+export function resolveSyncServerUrls({
+  settings,
+  serverInfo,
+  envSyncServerUrl,
+}: {
+  settings: SyncSettings
+  serverInfo: SyncServerInfo | undefined
+  envSyncServerUrl?: string
+}): SyncServerUrls {
+  const localUrl = serverInfo?.running ? serverInfo.url : undefined
+
+  const remoteUrl =
+    settings.syncServerMode === 'remote'
+      ? (settings.remoteSyncServerUrl ?? envSyncServerUrl)
+      : undefined
+
+  // No embedded server means nothing persists this session, so fall back to the
+  // build-time server rather than leaving the app with no peer at all.
+  if (!localUrl && !remoteUrl && envSyncServerUrl) {
+    return { remoteUrl: envSyncServerUrl }
+  }
+
+  return { localUrl, remoteUrl }
+}
+
+export function buildRendererNetwork({
+  localUrl,
+  remoteUrl,
+}: SyncServerUrls): NetworkAdapterInterface[] {
+  return [localUrl, remoteUrl]
+    .filter((url): url is string => Boolean(url))
+    .map((url) => new BrowserWebSocketClientAdapter(url))
+}

--- a/apps/electron-client/src/rendererRepoBootstrap.test.ts
+++ b/apps/electron-client/src/rendererRepoBootstrap.test.ts
@@ -1,0 +1,233 @@
+import { existsSync } from 'fs'
+import { mkdtemp, rm } from 'fs/promises'
+import { tmpdir } from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  Repo,
+  type AutomergeUrl,
+  type NetworkAdapterInterface,
+  type StorageAdapterInterface,
+} from '@automerge/automerge-repo'
+import { WebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
+import { NodeFSStorageAdapter } from '@automerge/automerge-repo-storage-nodefs'
+import type { RecordingRepoState } from '@tapes-monorepo/core'
+import { startSyncServer, stopSyncServer } from './syncServer'
+import { bootstrapRendererRepo, type SyncServerUrls } from './rendererRepo'
+
+/**
+ * Exercises the renderer's bootstrap against the real embedded sync server, so
+ * the paths that would otherwise only run on a user's machine — in particular
+ * the handoff of a pre-TAP-69 library the server has never seen — run in CI.
+ * `createStorage` stands in for IndexedDB (unavailable under node) with the same
+ * NodeFS adapter the server uses; the bootstrap only cares that it persists.
+ */
+
+let serverStoragePath: string | undefined
+let rendererStoragePath: string | undefined
+const openRepos: Repo[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    openRepos.splice(0).map(async (repo) => {
+      // A socket still mid-handshake throws on close; irrelevant to the test.
+      try {
+        await repo.shutdown()
+      } catch {
+        /* empty */
+      }
+    }),
+  )
+  await stopSyncServer()
+  for (const dir of [serverStoragePath, rendererStoragePath]) {
+    if (dir) {
+      await rm(dir, { recursive: true, force: true })
+    }
+  }
+  serverStoragePath = undefined
+  rendererStoragePath = undefined
+})
+
+async function serverStorage() {
+  serverStoragePath ??= await mkdtemp(path.join(tmpdir(), 'tapes-server-'))
+  return serverStoragePath
+}
+
+async function rendererStorage(): Promise<StorageAdapterInterface> {
+  rendererStoragePath ??= await mkdtemp(path.join(tmpdir(), 'tapes-renderer-'))
+  return new NodeFSStorageAdapter(rendererStoragePath)
+}
+
+/** The embedded sync server, on an OS-assigned port so suites never collide. */
+async function startServer() {
+  const info = await startSyncServer({
+    storagePath: await serverStorage(),
+    host: '127.0.0.1',
+    port: 0,
+    peerId: `test-host-${Math.random()}`,
+  })
+
+  // The server's storage id resolves asynchronously, and its peer metadata is
+  // pending until it does. A client that joins inside that window has its join
+  // dropped and never peers. In the app this cannot happen — main starts the
+  // server at `app.ready` and the renderer connects later, after an IPC
+  // round-trip — but a test that connects in the same tick would hit it every
+  // time, so mirror the real ordering.
+  await new Promise((resolve) => setTimeout(resolve, 500))
+
+  return info
+}
+
+// The renderer builds BrowserWebSocketClientAdapters; under node the ws-backed
+// adapter speaks the same protocol to the same server.
+function createNetwork(urls: SyncServerUrls): NetworkAdapterInterface[] {
+  return [urls.localUrl, urls.remoteUrl]
+    .filter((url): url is string => Boolean(url))
+    .map((url) => new WebSocketClientAdapter(url))
+}
+
+async function bootstrap(
+  storedUrl: AutomergeUrl | null,
+  urls: SyncServerUrls,
+  createStorage: () => StorageAdapterInterface,
+) {
+  const result = await bootstrapRendererRepo({
+    storedUrl,
+    urls,
+    createStorage,
+    createNetwork,
+    // Keep failures fast: these repos are either connected or deliberately not.
+    findTimeoutMs: 2_000,
+  })
+  if (result.status === 'ready') {
+    openRepos.push(result.repo)
+  }
+  return result
+}
+
+/** Writes a library into a storage adapter, as a previous session would have. */
+async function seedLibrary(storage: StorageAdapterInterface) {
+  const repo = new Repo({ storage })
+  const handle = repo.create<RecordingRepoState>({ recordings: [] })
+  handle.change((doc) => {
+    doc.recordings.push('automerge:seeded-recording' as AutomergeUrl)
+  })
+  await repo.flush()
+  await repo.shutdown()
+  return handle.url
+}
+
+/**
+ * Waits for the sync server to have written a document to disk. Syncing is
+ * asynchronous, and the layout is NodeFSStorageAdapter's: the first two
+ * characters of the document id name a directory holding the rest.
+ */
+async function waitForServerToStore(url: AutomergeUrl) {
+  const documentId = url.replace('automerge:', '')
+  const docPath = path.join(
+    await serverStorage(),
+    documentId.slice(0, 2),
+    documentId.slice(2),
+  )
+
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (existsSync(docPath)) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(`Sync server never stored ${url}`)
+}
+
+describe('bootstrapRendererRepo against the embedded sync server', () => {
+  const noRendererStorage = () => {
+    throw new Error('renderer storage should not be needed')
+  }
+
+  it('finds a library the server holds, without any renderer storage', async () => {
+    const url = await seedLibrary(new NodeFSStorageAdapter(await serverStorage()))
+    const info = await startServer()
+
+    const result = await bootstrap(url, { localUrl: info.url }, noRendererStorage)
+
+    expect(result.status).toBe('ready')
+    if (result.status !== 'ready') return
+    // The server's share policy never announces; this works only because it
+    // still answers for documents a peer explicitly requests.
+    expect(result.repo.storageSubsystem).toBeUndefined()
+    expect(result.handle.url).toBe(url)
+  })
+
+  it('creates a library when none is stored, and the server persists it', async () => {
+    const info = await startServer()
+
+    const result = await bootstrap(null, { localUrl: info.url }, noRendererStorage)
+
+    expect(result.status).toBe('ready')
+    if (result.status !== 'ready') return
+    expect(result.createdUrl).toBe(result.handle.url)
+
+    // The point of TAP-69: the renderer holds no storage, so this is only
+    // durable if the host wrote it to its own filesystem.
+    await waitForServerToStore(result.handle.url)
+  })
+
+  // The pre-TAP-69 migration: the library exists only in the renderer's own
+  // store, and the server has never seen it.
+  it('falls back to renderer storage and hands the library to the server', async () => {
+    const storage = await rendererStorage()
+    const url = await seedLibrary(storage)
+    const info = await startServer()
+
+    const result = await bootstrap(url, { localUrl: info.url }, () => storage)
+
+    expect(result.status).toBe('ready')
+    if (result.status !== 'ready') return
+    // Fell back to the store-backed repo rather than inventing a new document.
+    expect(result.repo.storageSubsystem).toBeDefined()
+    expect(result.handle.url).toBe(url)
+
+    // The handoff itself: the server received the library and wrote it to disk.
+    await waitForServerToStore(url)
+
+    // And so the next launch needs no renderer storage at all. Restarting the
+    // server proves the document came off disk rather than out of its memory.
+    await stopSyncServer()
+    const restarted = await startServer()
+    const nextLaunch = await bootstrap(
+      url,
+      { localUrl: restarted.url },
+      noRendererStorage,
+    )
+
+    expect(nextLaunch.status).toBe('ready')
+    if (nextLaunch.status !== 'ready') return
+    expect(nextLaunch.repo.storageSubsystem).toBeUndefined()
+    expect(nextLaunch.handle.url).toBe(url)
+  })
+
+  it('reports unavailable when neither the server nor renderer storage has it', async () => {
+    const info = await startServer()
+    const storage = await rendererStorage()
+
+    const result = await bootstrap(
+      'automerge:2j9knpCseyhnK8izDmLpGP5NdMdt' as AutomergeUrl,
+      { localUrl: info.url },
+      () => storage,
+    )
+
+    expect(result.status).toBe('unavailable')
+  })
+
+  it('uses renderer storage when no embedded server is running', async () => {
+    const storage = await rendererStorage()
+    const url = await seedLibrary(storage)
+
+    const result = await bootstrap(url, {}, () => storage)
+
+    expect(result.status).toBe('ready')
+    if (result.status !== 'ready') return
+    expect(result.repo.storageSubsystem).toBeDefined()
+    expect(result.handle.url).toBe(url)
+  })
+})

--- a/apps/web-client/package.json
+++ b/apps/web-client/package.json
@@ -18,6 +18,11 @@
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@automerge/automerge-repo": "^2.0.0",
+    "@automerge/automerge-repo-network-broadcastchannel": "^2.0.0",
+    "@automerge/automerge-repo-network-websocket": "^2.0.0",
+    "@automerge/automerge-repo-react-hooks": "^2.0.0",
+    "@automerge/automerge-repo-storage-indexeddb": "^2.0.0",
     "@tapes-monorepo/core": "*",
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",

--- a/apps/web-client/src/main.tsx
+++ b/apps/web-client/src/main.tsx
@@ -1,10 +1,19 @@
-import React from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import ReactDOM from 'react-dom/client'
-import { App } from '@tapes-monorepo/core'
+import { App, RecordingRepoState, useAutomergeUrl } from '@tapes-monorepo/core'
 import './index.css'
 import DownloadPrompt from './DownloadPrompt'
 import PwaUpdatePrompt from './PwaUpdatePrompt'
 import { resolveSyncServerUrl } from './syncServerUrl'
+import {
+  DocHandle,
+  isValidAutomergeUrl,
+  NetworkAdapterInterface,
+  Repo,
+} from '@automerge/automerge-repo'
+import { BroadcastChannelNetworkAdapter } from '@automerge/automerge-repo-network-broadcastchannel'
+import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
+import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb'
 
 // Where this bundle syncs, in precedence order:
 //
@@ -66,13 +75,63 @@ if (!window.Worker) {
     console.log('worker.onerror', event)
   }
 
+  // Builds the repo this shell hands to core: IndexedDB for storage, cross-tab
+  // BroadcastChannel always, and a websocket to whichever sync server resolved
+  // above (if any).
+  function WebClientRoot() {
+    const { automergeUrl, setAutomergeUrl } = useAutomergeUrl()
+    const [repo, setRepo] = useState<Repo | null>(null)
+    const handleRef = useRef<DocHandle<unknown> | null>(null)
+    const didInitRef = useRef(false)
+
+    useEffect(() => {
+      const initialize = async () => {
+        // Guard against re-init (StrictMode double-invoke, dep changes). A `repo`
+        // state check can't do this: initialize() is async and setRepo lands only
+        // at the end, so concurrent runs would each build a Repo and websocket.
+        if (didInitRef.current) {
+          return
+        }
+        didInitRef.current = true
+
+        const network: NetworkAdapterInterface[] = [
+          new BroadcastChannelNetworkAdapter(),
+        ]
+        if (syncServerUrl) {
+          network.push(new BrowserWebSocketClientAdapter(syncServerUrl))
+        }
+
+        const _repo = new Repo({
+          storage: new IndexedDBStorageAdapter(),
+          network,
+        })
+
+        if (automergeUrl && isValidAutomergeUrl(automergeUrl)) {
+          handleRef.current = await _repo.find(automergeUrl)
+        } else {
+          handleRef.current = _repo.create<RecordingRepoState>({
+            recordings: [],
+          })
+          setAutomergeUrl(handleRef.current.url)
+        }
+
+        setRepo(_repo)
+      }
+      initialize()
+    }, [automergeUrl, setAutomergeUrl])
+
+    return (
+      <App
+        appContextValue={{ type: 'web-client', worker }}
+        repoContextValue={repo}
+      />
+    )
+  }
+
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
       <div className="flex sm:hidden">
-        <App
-          appContextValue={{ type: 'web-client', worker }}
-          syncServerUrl={syncServerUrl}
-        />
+        <WebClientRoot />
       </div>
       <div className="mx-auto hidden h-screen w-screen max-w-screen-sm flex-col items-center justify-center gap-16 sm:flex">
         <DownloadPrompt />

--- a/packages/core/app/App.test.tsx
+++ b/packages/core/app/App.test.tsx
@@ -1,73 +1,12 @@
-import { StrictMode } from 'react'
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
-import type { AutomergeUrl } from '@automerge/automerge-repo'
+import type { Repo } from '@automerge/automerge-repo'
 import type { AppContextValue } from '@/context/AppContext'
 import { App } from './App'
 
-const STORED_URL = 'automerge:stored-doc'
-const CREATED_URL = 'automerge:created-doc' as AutomergeUrl
-
-// Every Repo construction, so tests can assert on the network array App built.
-const { repoConfigs, findCalls, createCalls, control } = vi.hoisted(() => ({
-  repoConfigs: [] as { network: unknown[]; storage: unknown }[],
-  findCalls: [] as string[],
-  createCalls: [] as unknown[],
-  // Lets one test hold find() open so App is observed mid-initialization.
-  control: { blockFind: false },
-}))
-
-// Hoisted: vi.mock factories run before the module body, so the stand-in
-// adapters have to exist by then.
-const { FakeBroadcastAdapter, FakeWebSocketAdapter, FakeStorageAdapter } =
-  vi.hoisted(() => ({
-    FakeBroadcastAdapter: class {
-      readonly kind = 'broadcast'
-    },
-    FakeWebSocketAdapter: class {
-      readonly kind = 'websocket'
-      constructor(public url: string) {}
-    },
-    FakeStorageAdapter: class {
-      readonly kind = 'indexeddb'
-    },
-  }))
-
-vi.mock('@automerge/automerge-repo-network-broadcastchannel', () => ({
-  BroadcastChannelNetworkAdapter: FakeBroadcastAdapter,
-}))
-
-vi.mock('@automerge/automerge-repo-network-websocket', () => ({
-  BrowserWebSocketClientAdapter: FakeWebSocketAdapter,
-}))
-
-vi.mock('@automerge/automerge-repo-storage-indexeddb', () => ({
-  IndexedDBStorageAdapter: FakeStorageAdapter,
-}))
-
-vi.mock('@automerge/automerge-repo', () => ({
-  isValidAutomergeUrl: (url: string) => url.startsWith('automerge:'),
-  Repo: class {
-    constructor(config: { network: unknown[]; storage: unknown }) {
-      repoConfigs.push(config)
-    }
-    async find(url: string) {
-      findCalls.push(url)
-      if (control.blockFind) {
-        await new Promise(() => {})
-      }
-      return { url }
-    }
-    create(initialValue: unknown) {
-      createCalls.push(initialValue)
-      return { url: CREATED_URL }
-    }
-  },
-}))
-
-// The view tree below App is irrelevant here — these tests are about how App
-// wires up the Repo — so collapse the providers and children to a marker that
-// tells us the async initialize() finished and `repo` state landed.
+// The view tree below App is irrelevant here — these tests are about the seam
+// between App and the shell that hands it a Repo — so collapse the providers
+// and children to a marker.
 vi.mock('./context/Providers', () => ({
   default: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="providers">{children}</div>
@@ -93,142 +32,31 @@ const appContextValue: AppContextValue = {
   worker: {} as unknown as Worker,
 }
 
-const renderApp = async (
-  syncServerUrl?: string | null,
-  { strict = false }: { strict?: boolean } = {},
-) => {
-  const tree = (
-    <App appContextValue={appContextValue} syncServerUrl={syncServerUrl} />
-  )
-  render(strict ? <StrictMode>{tree}</StrictMode> : tree)
-  await screen.findByTestId('providers')
-}
-
-const networkOf = (index = 0) => repoConfigs[index].network
-const adaptersOfKind = (kind: string, index = 0) =>
-  networkOf(index).filter(
-    (adapter) => (adapter as { kind: string }).kind === kind,
-  )
-
-beforeEach(() => {
-  repoConfigs.length = 0
-  findCalls.length = 0
-  createCalls.length = 0
-  control.blockFind = false
-  localStorage.clear()
-})
-
 afterEach(() => {
   cleanup()
 })
 
-describe('App network adapters', () => {
-  it('builds a repo with only the broadcast adapter when no sync url is given', async () => {
-    await renderApp(undefined)
-
-    expect(repoConfigs).toHaveLength(1)
-    expect(networkOf()).toHaveLength(1)
-    expect(adaptersOfKind('broadcast')).toHaveLength(1)
-    expect(adaptersOfKind('websocket')).toHaveLength(0)
-  })
-
-  // The point of making the prop optional: these are the values the call sites
-  // can hand over when there is no sync server, and none may produce a socket
-  // that then loops on failing reconnects.
-  it.each([
-    ['undefined', undefined],
-    ['null', null],
-    ['an empty string', ''],
-  ])(
-    'adds no websocket adapter when the sync url is %s',
-    async (_label, url) => {
-      await renderApp(url)
-
-      expect(adaptersOfKind('websocket')).toHaveLength(0)
-    },
-  )
-
-  it('adds a websocket adapter pointed at the sync url when one is given', async () => {
-    await renderApp('ws://192.168.1.2:9001')
-
-    expect(networkOf()).toHaveLength(2)
-    const [websocket] = adaptersOfKind('websocket') as InstanceType<
-      typeof FakeWebSocketAdapter
-    >[]
-    expect(websocket.url).toBe('ws://192.168.1.2:9001')
-  })
-
-  // Cross-tab sync must not depend on remote sync being configured.
-  it.each([
-    ['without a sync url', undefined],
-    ['with a sync url', 'ws://192.168.1.2:9001'],
-  ])('always includes the broadcast adapter %s', async (_label, url) => {
-    await renderApp(url)
-
-    expect(adaptersOfKind('broadcast')).toHaveLength(1)
-  })
-
-  it('uses IndexedDB for storage', async () => {
-    await renderApp(undefined)
-
-    expect(repoConfigs[0].storage).toBeInstanceOf(FakeStorageAdapter)
-  })
-})
-
-describe('App initialization guard', () => {
-  // didInitRef exists because initialize() is async and StrictMode double-invokes
-  // effects: without it each run builds its own Repo and its own websocket.
-  it('builds exactly one repo under StrictMode double-invocation', async () => {
-    await renderApp('ws://192.168.1.2:9001', { strict: true })
-
-    expect(repoConfigs).toHaveLength(1)
-    expect(adaptersOfKind('websocket')).toHaveLength(1)
-    expect(adaptersOfKind('broadcast')).toHaveLength(1)
-  })
-
-  it('creates the recordings doc only once under StrictMode', async () => {
-    await renderApp(undefined, { strict: true })
-
-    expect(createCalls).toEqual([{ recordings: [] }])
-  })
-})
-
-describe('App document bootstrap', () => {
-  it('creates a doc and persists its url when none is stored', async () => {
-    await renderApp(undefined)
-
-    expect(createCalls).toEqual([{ recordings: [] }])
-    expect(findCalls).toEqual([])
-    expect(localStorage.getItem('automergeUrl')).toBe(CREATED_URL)
-  })
-
-  it('finds the stored doc instead of creating a new one', async () => {
-    localStorage.setItem('automergeUrl', STORED_URL)
-
-    await renderApp(undefined)
-
-    expect(findCalls).toEqual([STORED_URL])
-    expect(createCalls).toEqual([])
-    expect(localStorage.getItem('automergeUrl')).toBe(STORED_URL)
-  })
-
-  it('creates a fresh doc when the stored url is not a valid automerge url', async () => {
-    localStorage.setItem('automergeUrl', 'not-an-automerge-url')
-
-    await renderApp(undefined)
-
-    expect(findCalls).toEqual([])
-    expect(createCalls).toEqual([{ recordings: [] }])
-    expect(localStorage.getItem('automergeUrl')).toBe(CREATED_URL)
-  })
-
-  it('renders a loading state until the repo is ready', () => {
-    localStorage.setItem('automergeUrl', STORED_URL)
-    control.blockFind = true
-
-    render(<App appContextValue={appContextValue} syncServerUrl={undefined} />)
+describe('App repo seam', () => {
+  // Each shell builds its own Repo (storage and network adapters differ per
+  // platform) and passes null until that bootstrap finishes.
+  it('renders a loading state while the shell has no repo yet', () => {
+    render(<App appContextValue={appContextValue} repoContextValue={null} />)
 
     expect(screen.getByText('Loading...')).toBeInTheDocument()
     expect(screen.queryByTestId('providers')).toBeNull()
+  })
+
+  it('renders the app tree once the shell provides a repo', () => {
+    // A stub stands in for a real Repo: App only forwards it to Providers
+    // (mocked above), and constructing one here would drag in Automerge's wasm.
+    render(
+      <App
+        appContextValue={appContextValue}
+        repoContextValue={{} as unknown as Repo}
+      />,
+    )
+
+    expect(screen.getByTestId('providers')).toBeInTheDocument()
+    expect(screen.queryByText('Loading...')).toBeNull()
   })
 })

--- a/packages/core/app/App.tsx
+++ b/packages/core/app/App.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { clsx } from 'clsx'
-import { IndexedDBStorageAdapter } from '@automerge/automerge-repo-storage-indexeddb'
-import { BroadcastChannelNetworkAdapter } from '@automerge/automerge-repo-network-broadcastchannel'
-import { BrowserWebSocketClientAdapter } from '@automerge/automerge-repo-network-websocket'
-import { DocHandle, isValidAutomergeUrl, NetworkAdapterInterface, Repo } from '@automerge/automerge-repo'
+import { Repo } from '@automerge/automerge-repo'
 import { Button } from '@tapes-monorepo/ui'
 import {
   useView,
@@ -11,64 +8,28 @@ import {
   viewComponentMap,
 } from '@/context/ViewContext'
 import './index.css'
-import { RecordingRepoState } from '@/types'
 import { AudioPlayer } from './components/AudioPlayer'
 import { useAudioPlayer } from './context/AudioPlayerContext'
 import Providers from './context/Providers'
 import { AppContextValue } from './context/AppContext'
-import { setAutomergeUrl, useAutomergeUrl } from './utils'
 
+/**
+ * The shared app tree. Each shell builds its own `Repo` and passes it in: the
+ * storage and network adapters a repo needs are platform-specific (the web
+ * client persists to IndexedDB, the electron renderer delegates persistence to
+ * the embedded sync server's filesystem store), and only the shell knows where
+ * its sync server lives. `null` means the shell is still bootstrapping.
+ */
 export function App({
   appContextValue,
-  syncServerUrl,
+  repoContextValue,
 }: {
   appContextValue: AppContextValue
-  syncServerUrl?: string | null
+  repoContextValue: Repo | null
 }) {
-  const { automergeUrl } = useAutomergeUrl()
-  const [repo, setRepo] = useState<Repo | null>(null)
   const mainRef = useRef<HTMLDivElement | null>(null)
-  const handleRef = useRef<DocHandle<unknown> | null>(null)
-  const didInitRef = useRef(false)
 
-  useEffect(() => {
-    const initialize = async () => {
-      // Guard against re-init (StrictMode double-invoke, dep changes). A `repo`
-      // state check can't do this: initialize() is async and setRepo lands only
-      // at the end, so concurrent runs would each build a Repo and websocket.
-      if (didInitRef.current) {
-        return
-      }
-      didInitRef.current = true
-
-      // Set up network adapters. 
-      const broadcast = new BroadcastChannelNetworkAdapter()
-      const network: NetworkAdapterInterface[] = [broadcast]
-      if (syncServerUrl) {
-        network.push(new BrowserWebSocketClientAdapter(syncServerUrl))
-      }
-  
-      const indexedDB = new IndexedDBStorageAdapter()
-
-      const _repo = new Repo({
-        storage: indexedDB,
-        network
-      })
-
-      if (automergeUrl && isValidAutomergeUrl(automergeUrl)) {
-        handleRef.current = await _repo.find(automergeUrl)
-      } else {
-        handleRef.current = _repo.create<RecordingRepoState>({ recordings: [] })
-        setAutomergeUrl(handleRef.current.url)
-      }
-
-      setRepo(_repo)
-    }
-    initialize()
-
-  }, [automergeUrl, syncServerUrl])
-
-  if (!repo) {
+  if (!repoContextValue) {
     return <div>Loading...</div>
   }
 
@@ -76,7 +37,7 @@ export function App({
     <Providers
       values={{
         appContext: appContextValue,
-        repoContext: repo,
+        repoContext: repoContextValue,
       }}
     >
       <Main mainRef={mainRef} />

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,2 +1,4 @@
 export * from './app/App'
 export * from './app/IpcService'
+export * from './app/types'
+export { useAutomergeUrl } from './app/utils'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,10 +31,7 @@
   },
   "dependencies": {
     "@automerge/automerge-repo": "^2.0.0",
-    "@automerge/automerge-repo-network-broadcastchannel": "^2.0.0",
-    "@automerge/automerge-repo-network-websocket": "^2.0.0",
     "@automerge/automerge-repo-react-hooks": "^2.0.0",
-    "@automerge/automerge-repo-storage-indexeddb": "^2.0.0",
     "@tapes-monorepo/ui": "*",
     "clsx": "^2.1.1",
     "qrcode.react": "^4.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5896,10 +5896,7 @@ __metadata:
   resolution: "@tapes-monorepo/core@workspace:packages/core"
   dependencies:
     "@automerge/automerge-repo": "npm:^2.0.0"
-    "@automerge/automerge-repo-network-broadcastchannel": "npm:^2.0.0"
-    "@automerge/automerge-repo-network-websocket": "npm:^2.0.0"
     "@automerge/automerge-repo-react-hooks": "npm:^2.0.0"
-    "@automerge/automerge-repo-storage-indexeddb": "npm:^2.0.0"
     "@tailwindcss/postcss": "npm:^4.3.3"
     "@tapes-monorepo/eslint-config": "npm:*"
     "@tapes-monorepo/tailwind-config": "npm:*"
@@ -9735,6 +9732,7 @@ __metadata:
     "@automerge/automerge": "npm:^3.0.0"
     "@automerge/automerge-repo": "npm:^2.0.0"
     "@automerge/automerge-repo-network-websocket": "npm:^2.0.0"
+    "@automerge/automerge-repo-storage-indexeddb": "npm:^2.0.0"
     "@automerge/automerge-repo-storage-nodefs": "npm:^2.0.0"
     "@dotenvx/dotenvx": "npm:^2.0.0"
     "@electron-forge/cli": "npm:^7.6.0"
@@ -19209,6 +19207,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "web-client@workspace:apps/web-client"
   dependencies:
+    "@automerge/automerge-repo": "npm:^2.0.0"
+    "@automerge/automerge-repo-network-broadcastchannel": "npm:^2.0.0"
+    "@automerge/automerge-repo-network-websocket": "npm:^2.0.0"
+    "@automerge/automerge-repo-react-hooks": "npm:^2.0.0"
+    "@automerge/automerge-repo-storage-indexeddb": "npm:^2.0.0"
     "@playwright/test": "npm:^1.61.1"
     "@tailwindcss/postcss": "npm:^4.3.3"
     "@tapes-monorepo/core": "npm:*"


### PR DESCRIPTION
Closes TAP-69.

## Why

The renderer persisted the whole library — including the audio bytes embedded in each recording doc (`RecordingData.audio`) — to IndexedDB, against a Chromium origin quota. The desktop client is also the LAN sync host, so it accumulates every guest's recordings and hits that ceiling first.

Putting `NodeFSStorageAdapter` in the renderer can't work: it runs with Electron's default sandbox and no node integration, and Vite externalizes `node:fs` for that bundle. But the main process **already** runs `NodeFSStorageAdapter` over `syncStoragePath()` inside the embedded sync server (`syncServer.ts`), persisting the very same documents. So this stops giving the renderer a second, quota-bound copy and lets the host's store be the disk of record — one copy on disk in `~/Library/Application Support/Tapes/sync-storage`.

This raises the ceiling; it doesn't change the growth rate. TAP-71 (moving audio bytes out of the CRDT entirely) is the durable fix.

## What changed

- **Repo construction moves out of core into each shell.** Storage and network adapters are platform-specific and only the shell knows where its sync server lives. `App` now takes `repoContextValue: Repo | null` and loses the `syncServerUrl` prop, which nothing in core used once the repo moved out (`Settings.tsx` fetches server info over IPC itself).
- **The electron renderer builds its `Repo` with no storage adapter.** The embedded server's share policy never announces, but `access` defaults to true and the synchronizer gates on `announce || (access && hasRequested)`, so a peer that requests a doc by URL still gets it.
- **Remote mode adds a second adapter instead of replacing the first.** The local server is always connected; otherwise a remote session would persist nothing on disk.
- **Pre-TAP-69 libraries migrate lazily.** If the server doesn't hold the stored doc, the session runs on the legacy IndexedDB-backed repo, which announces it to the server so the next launch finds it on disk. Self-verifying — no migration flag that could be set before the handoff lands.
- **Stored remote sync urls are validated as `ws:`/`wss:`**, mirroring web-client's `readRemoteSyncServerUrl`.

Two hazards found while wiring it up:

- Repo construction is now gated on the sync-server url arriving over IPC. Built before that, it has an empty network — with no local storage, `find` then has no peer to ask and reports the library unavailable.
- Every `find` carries a 10s timeout. The websocket adapter force-readies one second after construction whether or not it ever connected, so a peer that never answers leaves the promise pending forever. A session with no local server goes straight to IndexedDB rather than to a repo with zero adapters, and a stored-but-unavailable library surfaces an error rather than silently creating a fresh doc — which would look exactly like a lost library.

## Testing

`yarn check-types` (9/9), `yarn build` (6/6), core tests 20 passed, electron-client 20 passed (18 new in `rendererRepo.test.ts`), `eslint src` clean in every workspace touched. The renderer's Vite production build was run directly — 160 modules, no node-builtin externalization.

**Not yet verified — needs a running app:**

- [x] Record a tape; `sync-storage` grows, renderer IndexedDB does not
- [x] Playback survives a full app restart (doc round-trips from NodeFS over the loopback socket)
- [x] Migration path with a pre-change IndexedDB library in place (this path has never executed)
- [x] LAN guest pairing: record on guest, play on desktop and vice versa
- [x] Remote mode: both adapters connect and `sync-storage` still grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5KXf3jTxkgbnLSrsSwaP2
