### PR TITLE
feat(electron-client): content-addressed blob store and /blobs surface (TAP-71)

### DIFF
--- a/.changeset/tap-71-blob-store-infra.md
+++ b/.changeset/tap-71-blob-store-infra.md
@@ -1,0 +1,5 @@
+---
+'@tapes-monorepo/core': minor
+---
+
+Adds the client half of out-of-band audio storage, ahead of recordings actually using it. `blobClient` (`uploadBlob`/`fetchBlob`/`headBlob`/`deleteBlob`/`resolveBlobEndpoint`) talks to the sync host's new `/blobs` surface, and `callWorker` gives the web-client's storage worker a request/response helper with correlated ids so overlapping requests can no longer take each other's replies. `BlobDescriptor` is exported from `types`, and `SyncServerInfo` gains `blobBaseUrl`, `lanBlobBaseUrl` and `blobToken`. Nothing reads or writes these yet: `RecordingData` is unchanged and recordings still embed their audio.

--- a/apps/electron-client/src/blobHttp.test.ts
+++ b/apps/electron-client/src/blobHttp.test.ts
@@ -1,0 +1,360 @@
+import crypto from 'crypto'
+import http from 'http'
+import path from 'path'
+import { mkdtemp, readdir, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { afterEach, describe, expect, it } from 'vitest'
+import { startSyncServer, stopSyncServer } from './syncServer'
+import { createBlobStore } from './blobStore'
+import { createBlobRequestHandler } from './blobHttp'
+
+const TOKEN = 'test-blob-token'
+const DOC = 'automerge:doc-a'
+const AUDIO = 'pretend this is a wav file'
+const AUDIO_HASH = crypto.createHash('sha256').update(AUDIO).digest('hex')
+
+const dirs: string[] = []
+let extraServer: http.Server | undefined
+
+async function tempDir(prefix: string) {
+  const dir = await mkdtemp(path.join(tmpdir(), prefix))
+  dirs.push(dir)
+  return dir
+}
+
+afterEach(async () => {
+  await stopSyncServer()
+  if (extraServer) {
+    await new Promise<void>((resolve) => extraServer!.close(() => resolve()))
+    extraServer = undefined
+  }
+  await Promise.all(
+    dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  )
+})
+
+type Host = { origin: string; blobRoot: string }
+
+async function startHost(
+  options: { withBundle?: boolean; withStore?: boolean } = {},
+): Promise<Host> {
+  const { withBundle = false, withStore = true } = options
+  const storagePath = await tempDir('tapes-sync-')
+  const blobRoot = await tempDir('tapes-blobs-')
+
+  let webClientPath: string | undefined
+  if (withBundle) {
+    webClientPath = await tempDir('tapes-web-')
+    await writeFile(
+      path.join(webClientPath, 'index.html'),
+      '<!doctype html><title>Tapes</title>',
+    )
+  }
+
+  const info = await startSyncServer({
+    storagePath,
+    host: '127.0.0.1',
+    port: 0,
+    peerId: 'test-host',
+    webClientPath,
+    blobStorePath: withStore ? blobRoot : undefined,
+    blobToken: withStore ? TOKEN : undefined,
+  })
+
+  return { origin: `http://127.0.0.1:${info.port}`, blobRoot }
+}
+
+function upload(
+  origin: string,
+  body: string,
+  init: { token?: string | null; contentType?: string; doc?: string } = {},
+) {
+  const { token = TOKEN, contentType = 'audio/wav', doc = DOC } = init
+  const query = doc ? `?doc=${encodeURIComponent(doc)}` : ''
+  return fetch(`${origin}/blobs${query}`, {
+    method: 'POST',
+    headers: {
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      'Content-Type': contentType,
+    },
+    body,
+  })
+}
+
+const authed = (token: string | null = TOKEN) =>
+  token ? { Authorization: `Bearer ${token}` } : undefined
+
+describe('blob routes', () => {
+  it('advertises its origin and token on the server info', async () => {
+    const storagePath = await tempDir('tapes-sync-')
+    const blobRoot = await tempDir('tapes-blobs-')
+
+    const info = await startSyncServer({
+      storagePath,
+      host: '127.0.0.1',
+      port: 0,
+      peerId: 'test-host',
+      blobStorePath: blobRoot,
+      blobToken: TOKEN,
+    })
+
+    expect(info.blobBaseUrl).toBe(`http://127.0.0.1:${info.port}`)
+    expect(info.blobToken).toBe(TOKEN)
+  })
+
+  it('rejects an upload with no token', async () => {
+    const { origin } = await startHost()
+
+    const response = await upload(origin, AUDIO, { token: null })
+
+    expect(response.status).toBe(401)
+  })
+
+  it('stores an upload under the sha-256 of its bytes', async () => {
+    const { origin } = await startHost()
+
+    const response = await upload(origin, AUDIO)
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toMatchObject({
+      hash: AUDIO_HASH,
+      size: AUDIO.length,
+      mimeType: 'audio/wav',
+      ext: '.wav',
+      deduped: false,
+    })
+  })
+
+  it('dedups a re-upload of identical bytes', async () => {
+    const { origin, blobRoot } = await startHost()
+    await upload(origin, AUDIO)
+
+    const response = await upload(origin, AUDIO, { doc: 'automerge:doc-b' })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ deduped: true })
+    const shard = AUDIO_HASH.slice(0, 2)
+    expect(await readdir(path.join(blobRoot, 'objects', shard))).toHaveLength(1)
+  })
+
+  it('rejects a non-audio content type', async () => {
+    const { origin } = await startHost()
+
+    const response = await upload(origin, AUDIO, { contentType: 'text/plain' })
+
+    expect(response.status).toBe(415)
+  })
+
+  it('rejects an upload with no owning document', async () => {
+    const { origin } = await startHost()
+
+    const response = await upload(origin, AUDIO, { doc: '' })
+
+    expect(response.status).toBe(400)
+  })
+
+  it('serves the stored bytes with cache and range headers', async () => {
+    const { origin } = await startHost()
+    await upload(origin, AUDIO)
+
+    const response = await fetch(`${origin}/blobs/${AUDIO_HASH}`, {
+      headers: authed(),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe('audio/wav')
+    expect(response.headers.get('content-length')).toBe(String(AUDIO.length))
+    expect(response.headers.get('accept-ranges')).toBe('bytes')
+    expect(response.headers.get('etag')).toBe(`"${AUDIO_HASH}"`)
+    await expect(response.text()).resolves.toBe(AUDIO)
+  })
+
+  it('accepts the token as a query parameter', async () => {
+    const { origin } = await startHost()
+    await upload(origin, AUDIO)
+
+    const response = await fetch(`${origin}/blobs/${AUDIO_HASH}?t=${TOKEN}`)
+
+    expect(response.status).toBe(200)
+  })
+
+  it('answers a range request with a partial body', async () => {
+    const { origin } = await startHost()
+    await upload(origin, AUDIO)
+
+    const response = await fetch(`${origin}/blobs/${AUDIO_HASH}`, {
+      headers: { ...authed(), Range: 'bytes=0-9' },
+    })
+
+    expect(response.status).toBe(206)
+    expect(response.headers.get('content-length')).toBe('10')
+    expect(response.headers.get('content-range')).toBe(
+      `bytes 0-9/${AUDIO.length}`,
+    )
+    await expect(response.text()).resolves.toBe(AUDIO.slice(0, 10))
+  })
+
+  it('answers an unsatisfiable range with 416', async () => {
+    const { origin } = await startHost()
+    await upload(origin, AUDIO)
+
+    const response = await fetch(`${origin}/blobs/${AUDIO_HASH}`, {
+      headers: { ...authed(), Range: 'bytes=99999-' },
+    })
+
+    expect(response.status).toBe(416)
+    expect(response.headers.get('content-range')).toBe(
+      `bytes */${AUDIO.length}`,
+    )
+  })
+
+  it('answers HEAD with headers and no body', async () => {
+    const { origin } = await startHost()
+    await upload(origin, AUDIO)
+
+    const response = await fetch(`${origin}/blobs/${AUDIO_HASH}`, {
+      method: 'HEAD',
+      headers: authed(),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-length')).toBe(String(AUDIO.length))
+    await expect(response.text()).resolves.toBe('')
+  })
+
+  it('404s an unknown hash and 400s a malformed one', async () => {
+    const { origin } = await startHost()
+    const unknown = 'a'.repeat(64)
+
+    const missing = await fetch(`${origin}/blobs/${unknown}`, {
+      headers: authed(),
+    })
+    const malformed = await fetch(`${origin}/blobs/not-a-hash`, {
+      headers: authed(),
+    })
+
+    expect(missing.status).toBe(404)
+    expect(malformed.status).toBe(400)
+  })
+
+  it('releases the bytes when the last owner deletes', async () => {
+    const { origin } = await startHost()
+    await upload(origin, AUDIO)
+
+    const response = await fetch(
+      `${origin}/blobs/${AUDIO_HASH}?doc=${encodeURIComponent(DOC)}`,
+      { method: 'DELETE', headers: authed() },
+    )
+
+    expect(response.status).toBe(204)
+    const after = await fetch(`${origin}/blobs/${AUDIO_HASH}`, {
+      headers: authed(),
+    })
+    expect(after.status).toBe(404)
+  })
+
+  it('keeps the bytes while another document still references them', async () => {
+    const { origin } = await startHost()
+    await upload(origin, AUDIO)
+    await upload(origin, AUDIO, { doc: 'automerge:doc-b' })
+
+    await fetch(
+      `${origin}/blobs/${AUDIO_HASH}?doc=${encodeURIComponent(DOC)}`,
+      {
+        method: 'DELETE',
+        headers: authed(),
+      },
+    )
+
+    const after = await fetch(`${origin}/blobs/${AUDIO_HASH}`, {
+      headers: authed(),
+    })
+    expect(after.status).toBe(200)
+  })
+
+  it('answers 503 when the host has no blob store', async () => {
+    const { origin } = await startHost({ withStore: false })
+
+    const response = await fetch(`${origin}/blobs/${AUDIO_HASH}`)
+
+    expect(response.status).toBe(503)
+  })
+})
+
+describe('routing order', () => {
+  // The static handler answers *any* unmatched path with index.html and a 200.
+  // A blob route mounted after it would therefore hand an <audio> element a
+  // page of HTML instead of returning 404, which surfaces as an opaque decode
+  // error. These two assertions are the guard on that ordering.
+  it('404s an unknown blob rather than falling through to the SPA shell', async () => {
+    const { origin } = await startHost({ withBundle: true })
+
+    const response = await fetch(`${origin}/blobs/${'b'.repeat(64)}`, {
+      headers: authed(),
+    })
+
+    expect(response.status).toBe(404)
+    expect(response.headers.get('content-type')).toContain('application/json')
+  })
+
+  it('still serves the SPA shell for ordinary deep links', async () => {
+    const { origin } = await startHost({ withBundle: true })
+
+    const response = await fetch(`${origin}/some/deep/route`)
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain('<title>Tapes</title>')
+  })
+})
+
+describe('upload limits', () => {
+  // Driven through a bare server so the caps can be set to something a test
+  // can reach without moving hundreds of megabytes.
+  async function startCappedHost(caps: {
+    maxBlobBytes?: number
+    maxStoreBytes?: number
+  }) {
+    const blobRoot = await tempDir('tapes-blobs-')
+    const handle = createBlobRequestHandler({
+      store: createBlobStore(blobRoot),
+      token: TOKEN,
+      ...caps,
+    })
+    extraServer = http.createServer((request, response) => {
+      void handle(request, response).then((handled) => {
+        if (!handled) {
+          response.writeHead(404)
+          response.end()
+        }
+      })
+    })
+    const port = await new Promise<number>((resolve) => {
+      extraServer!.listen(0, '127.0.0.1', () => {
+        const address = extraServer!.address()
+        resolve(typeof address === 'object' && address ? address.port : 0)
+      })
+    })
+    return { origin: `http://127.0.0.1:${port}`, blobRoot }
+  }
+
+  it('rejects an oversized upload and leaves no temp file', async () => {
+    const { origin, blobRoot } = await startCappedHost({ maxBlobBytes: 8 })
+
+    const response = await upload(origin, 'far more than eight bytes')
+
+    expect(response.status).toBe(413)
+    expect(await readdir(path.join(blobRoot, 'tmp'))).toEqual([])
+  })
+
+  it('refuses uploads once the store budget is spent', async () => {
+    const { origin } = await startCappedHost({ maxStoreBytes: 4 })
+
+    const response = await upload(origin, AUDIO)
+    expect(response.status).toBe(201)
+
+    const second = await upload(origin, 'different audio bytes', {
+      doc: 'automerge:doc-b',
+    })
+    expect(second.status).toBe(507)
+  })
+})

--- a/apps/electron-client/src/blobHttp.ts
+++ b/apps/electron-client/src/blobHttp.ts
@@ -1,0 +1,350 @@
+import crypto from 'crypto'
+import type http from 'http'
+import { pipeline } from 'stream/promises'
+import { BlobTooLargeError, isValidBlobHash, type BlobStore } from './blobStore'
+
+/**
+ * The `/blobs` HTTP surface, served from the same origin and port as the sync
+ * socket so a guest needs no second address (and, over HTTPS, no second cert
+ * exception).
+ *
+ * Mounted ahead of everything else in `syncServer`'s request handler. That
+ * ordering is load-bearing: the static handler's SPA fallback answers *any*
+ * unmatched path with `index.html` and a 200, so a blob route mounted after it
+ * would not 404 — it would hand the audio element a page of HTML and fail as a
+ * decode error.
+ */
+
+export const BLOB_PATH_PREFIX = '/blobs'
+
+/** Per-upload ceiling. Well above any plausible recording; a stop, not a policy. */
+export const DEFAULT_MAX_BLOB_BYTES = 512 * 1024 * 1024
+
+/** Whole-store ceiling, so a paired peer cannot fill the host's disk. */
+export const DEFAULT_MAX_STORE_BYTES = 32 * 1024 * 1024 * 1024
+
+const CORS_HEADERS: Record<string, string> = {
+  // Safe as a wildcard only because authorization is a bearer token and never
+  // a cookie: a hostile page can send the request but cannot mint the token.
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,HEAD,POST,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers': 'authorization,content-type,range',
+  'Access-Control-Expose-Headers':
+    'content-length,content-range,accept-ranges,etag',
+  'Access-Control-Max-Age': '86400',
+}
+
+export type BlobHandlerOptions = {
+  store: BlobStore
+  /**
+   * Shared secret from `sync-server.json`, handed to guests through the
+   * existing QR pairing URL. Absent only in tests that exercise the unguarded
+   * shape.
+   */
+  token?: string
+  maxBlobBytes?: number
+  maxStoreBytes?: number
+}
+
+function sendJson(
+  response: http.ServerResponse,
+  status: number,
+  body: unknown,
+) {
+  const payload = JSON.stringify(body)
+  response.writeHead(status, {
+    ...CORS_HEADERS,
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(payload),
+  })
+  response.end(payload)
+}
+
+function sendStatus(response: http.ServerResponse, status: number) {
+  response.writeHead(status, CORS_HEADERS)
+  response.end()
+}
+
+function timingSafeMatch(a: string, b: string): boolean {
+  const left = Buffer.from(a)
+  const right = Buffer.from(b)
+  // timingSafeEqual throws on length mismatch, which would itself leak length.
+  if (left.length !== right.length) {
+    return false
+  }
+  return crypto.timingSafeEqual(left, right)
+}
+
+/**
+ * Accepts the token as a bearer header or as `?t=`. The query form exists so a
+ * plain `<audio src>` can stream a range directly one day — an element cannot
+ * set headers.
+ */
+function isAuthorized(
+  request: http.IncomingMessage,
+  url: URL,
+  token?: string,
+): boolean {
+  if (!token) {
+    return true
+  }
+  const header = request.headers.authorization
+  if (header?.startsWith('Bearer ')) {
+    return timingSafeMatch(header.slice('Bearer '.length), token)
+  }
+  const query = url.searchParams.get('t')
+  return query !== null && timingSafeMatch(query, token)
+}
+
+type ParsedRange =
+  | { kind: 'ok'; start: number; end: number }
+  | { kind: 'unsatisfiable' }
+  | { kind: 'none' }
+
+/**
+ * Single-range `bytes=` parsing. A multi-range request is answered with the
+ * whole body, which the spec permits and no audio element asks for.
+ */
+export function parseRange(
+  header: string | undefined,
+  size: number,
+): ParsedRange {
+  if (!header) {
+    return { kind: 'none' }
+  }
+  const match = /^bytes=(\d*)-(\d*)$/.exec(header.trim())
+  if (!match) {
+    return { kind: 'none' }
+  }
+  const [, rawStart, rawEnd] = match
+  if (rawStart === '' && rawEnd === '') {
+    return { kind: 'unsatisfiable' }
+  }
+
+  if (rawStart === '') {
+    // Suffix form: the final N bytes.
+    const suffix = Number(rawEnd)
+    if (suffix === 0) {
+      return { kind: 'unsatisfiable' }
+    }
+    const start = Math.max(0, size - suffix)
+    return { kind: 'ok', start, end: size - 1 }
+  }
+
+  const start = Number(rawStart)
+  if (start >= size) {
+    return { kind: 'unsatisfiable' }
+  }
+  const end = rawEnd === '' ? size - 1 : Math.min(Number(rawEnd), size - 1)
+  if (end < start) {
+    return { kind: 'unsatisfiable' }
+  }
+  return { kind: 'ok', start, end }
+}
+
+export function createBlobRequestHandler(options: BlobHandlerOptions) {
+  const {
+    store,
+    token,
+    maxBlobBytes = DEFAULT_MAX_BLOB_BYTES,
+    maxStoreBytes = DEFAULT_MAX_STORE_BYTES,
+  } = options
+
+  async function handleUpload(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+    url: URL,
+  ) {
+    const contentType = (request.headers['content-type'] ?? '')
+      .split(';')[0]
+      .trim()
+      .toLowerCase()
+    if (!contentType.startsWith('audio/')) {
+      request.resume()
+      sendJson(response, 415, { error: 'Expected an audio/* Content-Type' })
+      return
+    }
+
+    const docUrl =
+      url.searchParams.get('doc') ??
+      (request.headers['x-tapes-recording-url'] as string | undefined)
+    if (!docUrl) {
+      request.resume()
+      sendJson(response, 400, { error: 'Missing owning document url' })
+      return
+    }
+
+    if ((await store.totalBytes()) >= maxStoreBytes) {
+      request.resume()
+      sendJson(response, 507, { error: 'Blob store is full' })
+      return
+    }
+
+    try {
+      const { meta, deduped } = await store.ingestStream(request, {
+        mimeType: contentType,
+        docUrl,
+        maxBytes: maxBlobBytes,
+      })
+      sendJson(response, deduped ? 200 : 201, {
+        hash: meta.hash,
+        size: meta.size,
+        mimeType: meta.mimeType,
+        ext: meta.ext,
+        deduped,
+      })
+    } catch (error) {
+      if (error instanceof BlobTooLargeError) {
+        sendJson(response, 413, { error: error.message })
+        // The client may still be mid-upload; without this it would keep
+        // pushing bytes at a socket that has already been answered.
+        request.destroy()
+        return
+      }
+      throw error
+    }
+  }
+
+  async function handleDownload(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+    hash: string,
+    method: 'GET' | 'HEAD',
+  ) {
+    const meta = await store.stat(hash)
+    if (!meta) {
+      sendJson(response, 404, { error: 'Unknown blob' })
+      return
+    }
+
+    const range = parseRange(request.headers.range, meta.size)
+    if (range.kind === 'unsatisfiable') {
+      response.writeHead(416, {
+        ...CORS_HEADERS,
+        'Content-Range': `bytes */${meta.size}`,
+      })
+      response.end()
+      return
+    }
+
+    const headers: Record<string, string> = {
+      ...CORS_HEADERS,
+      'Content-Type': meta.mimeType,
+      'Accept-Ranges': 'bytes',
+      ETag: `"${meta.hash}"`,
+      // Content addressing makes the body immutable by construction.
+      'Cache-Control': 'private, max-age=31536000, immutable',
+      'Content-Disposition': `inline; filename="${meta.hash}${meta.ext}"`,
+    }
+
+    if (range.kind === 'ok') {
+      headers['Content-Length'] = String(range.end - range.start + 1)
+      headers['Content-Range'] =
+        `bytes ${range.start}-${range.end}/${meta.size}`
+      response.writeHead(206, headers)
+    } else {
+      headers['Content-Length'] = String(meta.size)
+      response.writeHead(200, headers)
+    }
+
+    if (method === 'HEAD') {
+      response.end()
+      return
+    }
+
+    const body =
+      range.kind === 'ok'
+        ? store.read(hash, { start: range.start, end: range.end })
+        : store.read(hash)
+    try {
+      await pipeline(body, response)
+    } catch {
+      // Client hung up mid-stream; pipeline has already torn the read down.
+      response.destroy()
+    }
+  }
+
+  async function handleDelete(
+    response: http.ServerResponse,
+    url: URL,
+    hash: string,
+  ) {
+    const docUrl = url.searchParams.get('doc')
+    if (!docUrl) {
+      sendJson(response, 400, { error: 'Missing owning document url' })
+      return
+    }
+    if (!(await store.has(hash))) {
+      sendJson(response, 404, { error: 'Unknown blob' })
+      return
+    }
+    await store.releaseRef(hash, docUrl)
+    sendStatus(response, 204)
+  }
+
+  /**
+   * Returns true when the request was a blob request and has been answered, so
+   * the caller knows not to fall through to the static handler.
+   */
+  return async function handleBlobRequest(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ): Promise<boolean> {
+    const url = new URL(request.url ?? '/', 'http://localhost')
+    const pathname = url.pathname
+    if (
+      pathname !== BLOB_PATH_PREFIX &&
+      !pathname.startsWith(`${BLOB_PATH_PREFIX}/`)
+    ) {
+      return false
+    }
+
+    const method = request.method ?? 'GET'
+    if (method === 'OPTIONS') {
+      sendStatus(response, 204)
+      return true
+    }
+
+    if (!isAuthorized(request, url, token)) {
+      request.resume()
+      sendJson(response, 401, { error: 'Unauthorized' })
+      return true
+    }
+
+    try {
+      if (pathname === BLOB_PATH_PREFIX) {
+        if (method === 'POST') {
+          await handleUpload(request, response, url)
+        } else {
+          sendJson(response, 405, { error: 'Method not allowed' })
+        }
+        return true
+      }
+
+      const hash = decodeURIComponent(
+        pathname.slice(`${BLOB_PATH_PREFIX}/`.length),
+      )
+      if (!isValidBlobHash(hash)) {
+        sendJson(response, 400, { error: 'Malformed blob hash' })
+        return true
+      }
+
+      if (method === 'GET' || method === 'HEAD') {
+        await handleDownload(request, response, hash, method)
+      } else if (method === 'DELETE') {
+        await handleDelete(response, url, hash)
+      } else {
+        sendJson(response, 405, { error: 'Method not allowed' })
+      }
+      return true
+    } catch (error) {
+      console.error('Blob request failed:', error)
+      if (!response.headersSent) {
+        sendJson(response, 500, { error: 'Blob request failed' })
+      } else {
+        response.destroy()
+      }
+      return true
+    }
+  }
+}

--- a/apps/electron-client/src/blobStore.test.ts
+++ b/apps/electron-client/src/blobStore.test.ts
@@ -1,0 +1,218 @@
+import crypto from 'crypto'
+import path from 'path'
+import { Readable } from 'stream'
+import { mkdtemp, readdir, rename, rm, stat, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { BlobTooLargeError, createBlobStore } from './blobStore'
+
+let root: string
+let workspace: string
+
+beforeEach(async () => {
+  root = await mkdtemp(path.join(tmpdir(), 'tapes-blobs-'))
+  workspace = await mkdtemp(path.join(tmpdir(), 'tapes-recordings-'))
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+  await rm(workspace, { recursive: true, force: true })
+})
+
+const sha256 = (value: string | Buffer) =>
+  crypto.createHash('sha256').update(value).digest('hex')
+
+async function writeRecording(name: string, contents: string) {
+  const filepath = path.join(workspace, name)
+  await writeFile(filepath, contents)
+  return filepath
+}
+
+const DOC_A = 'automerge:doc-a'
+const DOC_B = 'automerge:doc-b'
+
+describe('ingestFile', () => {
+  it('hardlinks the recording rather than copying it', async () => {
+    const store = createBlobStore(root)
+    const filepath = await writeRecording('take.wav', 'the audio')
+
+    const result = await store.ingestFile(filepath, { docUrl: DOC_A })
+
+    expect(result.mode).toBe('hardlink')
+    expect(result.deduped).toBe(false)
+    expect(result.meta.hash).toBe(sha256('the audio'))
+    expect(result.meta.mimeType).toBe('audio/wav')
+    expect(result.meta.ext).toBe('.wav')
+    // Two links to one inode: the user's file and the store object.
+    expect((await stat(filepath)).nlink).toBe(2)
+  })
+
+  // The reason the store is content-addressed at all: EditRecordingChannel
+  // renames the user's file on disk whenever a recording is retitled, so
+  // anything that served by path would break the moment a tape was renamed.
+  it('keeps serving after the source file is renamed', async () => {
+    const store = createBlobStore(root)
+    const filepath = await writeRecording('take.wav', 'the audio')
+    const { meta } = await store.ingestFile(filepath, { docUrl: DOC_A })
+
+    await rename(filepath, path.join(workspace, 'My first tape.wav'))
+
+    expect(await store.has(meta.hash)).toBe(true)
+    const streamed = await streamToString(store.read(meta.hash))
+    expect(streamed).toBe('the audio')
+  })
+
+  it('dedups identical content from two different files', async () => {
+    const store = createBlobStore(root)
+    const first = await writeRecording('one.wav', 'same bytes')
+    const second = await writeRecording('two.wav', 'same bytes')
+
+    const a = await store.ingestFile(first, { docUrl: DOC_A })
+    const b = await store.ingestFile(second, { docUrl: DOC_B })
+
+    expect(b.deduped).toBe(true)
+    expect(b.meta.hash).toBe(a.meta.hash)
+    expect(await store.refs(a.meta.hash)).toEqual([DOC_A, DOC_B])
+    const shard = a.meta.hash.slice(0, 2)
+    expect(await readdir(path.join(root, 'objects', shard))).toHaveLength(1)
+  })
+
+  it('falls back to a copy when the filesystem will not link', async () => {
+    // CI has no second filesystem, so EXDEV is injected.
+    const store = createBlobStore(root, {
+      link: async () => {
+        const error: NodeJS.ErrnoException = new Error('cross-device link')
+        error.code = 'EXDEV'
+        throw error
+      },
+    })
+    const filepath = await writeRecording('take.wav', 'the audio')
+
+    const result = await store.ingestFile(filepath, { docUrl: DOC_A })
+
+    expect(result.mode).toBe('copy')
+    expect((await stat(filepath)).nlink).toBe(1)
+    expect(await streamToString(store.read(result.meta.hash))).toBe('the audio')
+  })
+})
+
+describe('ingestStream', () => {
+  it('hashes the uploaded bytes and stores them', async () => {
+    const store = createBlobStore(root)
+
+    const { meta, deduped } = await store.ingestStream(
+      Readable.from([Buffer.from('streamed audio')]),
+      { mimeType: 'audio/mp4', docUrl: DOC_A },
+    )
+
+    expect(deduped).toBe(false)
+    expect(meta.hash).toBe(sha256('streamed audio'))
+    expect(meta.size).toBe('streamed audio'.length)
+    expect(meta.ext).toBe('.mp4')
+    expect(await streamToString(store.read(meta.hash))).toBe('streamed audio')
+  })
+
+  it('rejects an oversized upload and leaves no temp file behind', async () => {
+    const store = createBlobStore(root)
+
+    await expect(
+      store.ingestStream(Readable.from([Buffer.alloc(64)]), {
+        mimeType: 'audio/mp4',
+        docUrl: DOC_A,
+        maxBytes: 16,
+      }),
+    ).rejects.toBeInstanceOf(BlobTooLargeError)
+
+    expect(await readdir(path.join(root, 'tmp'))).toEqual([])
+  })
+})
+
+describe('refcounting', () => {
+  it('keeps the object until the last owner releases it', async () => {
+    const store = createBlobStore(root)
+    const filepath = await writeRecording('take.wav', 'shared audio')
+    const { meta } = await store.ingestFile(filepath, { docUrl: DOC_A })
+    await store.addRef(meta.hash, DOC_B)
+
+    const first = await store.releaseRef(meta.hash, DOC_A)
+    expect(first.removed).toBe(false)
+    expect(await store.has(meta.hash)).toBe(true)
+
+    const second = await store.releaseRef(meta.hash, DOC_B)
+    expect(second.removed).toBe(true)
+    expect(await store.has(meta.hash)).toBe(false)
+    expect(await store.stat(meta.hash)).toBeNull()
+  })
+
+  it('ignores a release from a document that never held a ref', async () => {
+    const store = createBlobStore(root)
+    const filepath = await writeRecording('take.wav', 'audio')
+    const { meta } = await store.ingestFile(filepath, { docUrl: DOC_A })
+
+    const result = await store.releaseRef(meta.hash, 'automerge:stranger')
+
+    expect(result.removed).toBe(false)
+    expect(await store.has(meta.hash)).toBe(true)
+  })
+
+  it('does not lose refs added concurrently', async () => {
+    const store = createBlobStore(root)
+    const filepath = await writeRecording('take.wav', 'audio')
+    const { meta } = await store.ingestFile(filepath, { docUrl: DOC_A })
+
+    const docs = Array.from(
+      { length: 12 },
+      (_, index) => `automerge:doc-${index}`,
+    )
+    await Promise.all(docs.map((doc) => store.addRef(meta.hash, doc)))
+
+    expect((await store.refs(meta.hash)).sort()).toEqual(
+      [DOC_A, ...docs].sort(),
+    )
+  })
+})
+
+describe('housekeeping', () => {
+  it('reports the total bytes held', async () => {
+    const store = createBlobStore(root)
+    await store.ingestStream(Readable.from([Buffer.alloc(100)]), {
+      mimeType: 'audio/mp4',
+      docUrl: DOC_A,
+    })
+    await store.ingestStream(Readable.from([Buffer.alloc(50, 1)]), {
+      mimeType: 'audio/mp4',
+      docUrl: DOC_B,
+    })
+
+    expect(await store.totalBytes()).toBe(150)
+  })
+
+  it('sweeps only stale temp files', async () => {
+    const store = createBlobStore(root)
+    // Create the tmp dir via a real ingest, then plant an abandoned upload.
+    await store.ingestStream(Readable.from([Buffer.from('x')]), {
+      mimeType: 'audio/mp4',
+      docUrl: DOC_A,
+    })
+    const stale = path.join(root, 'tmp', 'abandoned')
+    await writeFile(stale, 'partial')
+    const fresh = path.join(root, 'tmp', 'in-flight')
+    await writeFile(fresh, 'partial')
+    const { utimes } = await import('fs/promises')
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1000)
+    await utimes(stale, old, old)
+
+    const removed = await store.sweepTmp(24 * 60 * 60 * 1000)
+
+    expect(removed).toBe(1)
+    expect(await readdir(path.join(root, 'tmp'))).toEqual(['in-flight'])
+  })
+})
+
+async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk))
+  }
+  return Buffer.concat(chunks).toString('utf-8')
+}

--- a/apps/electron-client/src/blobStore.ts
+++ b/apps/electron-client/src/blobStore.ts
@@ -1,0 +1,463 @@
+import crypto from 'crypto'
+import path from 'path'
+import { createReadStream, createWriteStream, type ReadStream } from 'fs'
+import {
+  link,
+  copyFile,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from 'fs/promises'
+import { pipeline } from 'stream/promises'
+import type { Readable } from 'stream'
+
+/**
+ * A content-addressed store for recorded audio, owned by the sync host.
+ *
+ * Recordings are addressed by the sha-256 of their bytes rather than by path
+ * because the path is not stable: audio files live in a directory the user
+ * chose, and `EditRecordingChannel` renames the file on disk whenever the
+ * recording is retitled. `ingestFile` therefore hardlinks the user's file into
+ * the store, so the object and the user's copy share an inode and a rename
+ * cannot break serving.
+ *
+ * Deliberately free of any `electron` import: `syncServer.ts` imports nothing
+ * from electron, which is what lets the HTTP surface be tested against a real
+ * server in a plain node process. Path resolution lives in `syncServerConfig`.
+ */
+
+const HASH_PATTERN = /^[0-9a-f]{64}$/
+
+export type BlobMeta = {
+  hash: string
+  size: number
+  mimeType: string
+  /** Leading-dot extension, e.g. '.wav'. Used for cache filenames. */
+  ext: string
+  createdAt: string
+}
+
+export type IngestResult = {
+  meta: BlobMeta
+  /** True when the bytes were already in the store; only a ref was added. */
+  deduped: boolean
+}
+
+export type IngestFileResult = IngestResult & {
+  mode: 'hardlink' | 'copy' | 'deduped'
+}
+
+export type BlobStoreDeps = {
+  /**
+   * Injected so the cross-filesystem fallback can be exercised in tests: CI
+   * has no second filesystem to produce a real EXDEV.
+   */
+  link?: typeof link
+}
+
+export class BlobTooLargeError extends Error {
+  readonly code = 'BLOB_TOO_LARGE'
+  constructor(readonly limit: number) {
+    super(`Blob exceeds the ${limit} byte limit`)
+  }
+}
+
+export const MIME_TYPE_BY_EXTENSION: Record<string, string> = {
+  '.wav': 'audio/wav',
+  '.mp3': 'audio/mpeg',
+  '.ogg': 'audio/ogg',
+  '.flac': 'audio/flac',
+  '.mp4': 'audio/mp4',
+  '.m4a': 'audio/mp4',
+  '.webm': 'audio/webm',
+}
+
+export const EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  'audio/wav': '.wav',
+  'audio/x-wav': '.wav',
+  'audio/wave': '.wav',
+  'audio/mpeg': '.mp3',
+  'audio/ogg': '.ogg',
+  'audio/flac': '.flac',
+  'audio/mp4': '.mp4',
+  'audio/webm': '.webm',
+}
+
+export function isValidBlobHash(hash: string): boolean {
+  return HASH_PATTERN.test(hash)
+}
+
+/**
+ * Two-character fanout. A flat directory of objects degrades badly on ext4 and
+ * NTFS once a library grows into the thousands.
+ */
+function shard(hash: string): string {
+  return hash.slice(0, 2)
+}
+
+export type BlobStore = ReturnType<typeof createBlobStore>
+
+export function createBlobStore(root: string, deps: BlobStoreDeps = {}) {
+  const linkFile = deps.link ?? link
+
+  const tmpDir = path.join(root, 'tmp')
+  const objectPath = (hash: string) =>
+    path.join(root, 'objects', shard(hash), hash)
+  const metaPath = (hash: string) =>
+    path.join(root, 'meta', shard(hash), `${hash}.json`)
+  const refsPath = (hash: string) =>
+    path.join(root, 'refs', shard(hash), `${hash}.json`)
+
+  // The host is a single process, so serializing ref mutations per hash in
+  // memory is enough to keep the refs file consistent under concurrent
+  // uploads of the same content.
+  const locks = new Map<string, Promise<void>>()
+
+  function withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const tail = locks.get(key) ?? Promise.resolve()
+    // Run whether or not the previous holder settled successfully; one
+    // failed ingest must not wedge the queue for that hash.
+    const run = tail.then(fn, fn)
+    const settled = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    locks.set(key, settled)
+    void settled.then(() => {
+      if (locks.get(key) === settled) {
+        locks.delete(key)
+      }
+    })
+    return run
+  }
+
+  async function writeJsonAtomic(target: string, value: unknown) {
+    await mkdir(path.dirname(target), { recursive: true })
+    const scratch = path.join(tmpDir, `${crypto.randomUUID()}.json`)
+    await mkdir(tmpDir, { recursive: true })
+    await writeFile(scratch, JSON.stringify(value, null, 2))
+    await rename(scratch, target)
+  }
+
+  async function readRefs(hash: string): Promise<string[]> {
+    try {
+      const parsed = JSON.parse(await readFile(refsPath(hash), 'utf-8')) as {
+        refs?: unknown
+      }
+      return Array.isArray(parsed.refs)
+        ? parsed.refs.filter((ref): ref is string => typeof ref === 'string')
+        : []
+    } catch {
+      return []
+    }
+  }
+
+  async function readMeta(hash: string): Promise<BlobMeta | null> {
+    try {
+      return JSON.parse(await readFile(metaPath(hash), 'utf-8')) as BlobMeta
+    } catch {
+      return null
+    }
+  }
+
+  async function has(hash: string): Promise<boolean> {
+    if (!isValidBlobHash(hash)) {
+      return false
+    }
+    try {
+      await stat(objectPath(hash))
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  /** Metadata for a stored blob, or null when the object is not present. */
+  async function statBlob(hash: string): Promise<BlobMeta | null> {
+    if (!isValidBlobHash(hash)) {
+      return null
+    }
+    const meta = await readMeta(hash)
+    if (!meta) {
+      return null
+    }
+    // The meta file can outlive its object if a delete was interrupted, so
+    // the object is the source of truth for presence.
+    try {
+      const stats = await stat(objectPath(hash))
+      return { ...meta, size: stats.size }
+    } catch {
+      return null
+    }
+  }
+
+  function readBlob(
+    hash: string,
+    range?: { start?: number; end?: number },
+  ): ReadStream {
+    return createReadStream(objectPath(hash), range)
+  }
+
+  async function addRef(hash: string, docUrl: string): Promise<string[]> {
+    return withLock(hash, async () => {
+      const refs = await readRefs(hash)
+      if (refs.includes(docUrl)) {
+        return refs
+      }
+      const next = [...refs, docUrl]
+      await writeJsonAtomic(refsPath(hash), { refs: next })
+      return next
+    })
+  }
+
+  /**
+   * Drops one owner. When the last owner goes the bytes are unlinked — this is
+   * what makes deleting a recording actually reclaim space, which embedding
+   * the audio in the Automerge doc could never do.
+   */
+  async function releaseRef(
+    hash: string,
+    docUrl: string,
+  ): Promise<{ removed: boolean; refs: string[] }> {
+    return withLock(hash, async () => {
+      const refs = await readRefs(hash)
+      const next = refs.filter((ref) => ref !== docUrl)
+      if (next.length === refs.length && refs.length > 0) {
+        return { removed: false, refs }
+      }
+      if (next.length > 0) {
+        await writeJsonAtomic(refsPath(hash), { refs: next })
+        return { removed: false, refs: next }
+      }
+      await Promise.all([
+        rm(objectPath(hash), { force: true }),
+        rm(metaPath(hash), { force: true }),
+        rm(refsPath(hash), { force: true }),
+      ])
+      return { removed: true, refs: [] }
+    })
+  }
+
+  async function finalizeMeta(
+    hash: string,
+    size: number,
+    mimeType: string,
+    ext: string,
+  ): Promise<BlobMeta> {
+    const meta: BlobMeta = {
+      hash,
+      size,
+      mimeType,
+      ext,
+      createdAt: new Date().toISOString(),
+    }
+    await writeJsonAtomic(metaPath(hash), meta)
+    return meta
+  }
+
+  function resolveExt(mimeType: string, fallbackExt?: string): string {
+    if (fallbackExt) {
+      return fallbackExt.startsWith('.') ? fallbackExt : `.${fallbackExt}`
+    }
+    return EXTENSION_BY_MIME_TYPE[mimeType] ?? '.bin'
+  }
+
+  /**
+   * Streams an upload into the store, hashing as it goes. Hashing on the host
+   * rather than the client keeps a phone from having to read a 50 MB+ file
+   * into memory, and avoids `crypto.subtle`, which is unavailable in the
+   * plain-HTTP LAN mode the host can be configured into.
+   */
+  async function ingestStream(
+    source: Readable,
+    options: {
+      mimeType: string
+      ext?: string
+      docUrl: string
+      maxBytes?: number
+    },
+  ): Promise<IngestResult> {
+    await mkdir(tmpDir, { recursive: true })
+    const scratch = path.join(tmpDir, crypto.randomUUID())
+    const hasher = crypto.createHash('sha256')
+    let size = 0
+    let tooLarge = false
+
+    const sink = createWriteStream(scratch)
+    try {
+      await pipeline(
+        source,
+        async function* (chunks: AsyncIterable<Buffer>) {
+          for await (const chunk of chunks) {
+            size += chunk.length
+            if (options.maxBytes !== undefined && size > options.maxBytes) {
+              tooLarge = true
+              throw new BlobTooLargeError(options.maxBytes)
+            }
+            hasher.update(chunk)
+            yield chunk
+          }
+        },
+        sink,
+      )
+    } catch (error) {
+      await rm(scratch, { force: true })
+      throw tooLarge ? new BlobTooLargeError(options.maxBytes ?? 0) : error
+    }
+
+    const hash = hasher.digest('hex')
+    const ext = resolveExt(options.mimeType, options.ext)
+
+    if (await has(hash)) {
+      await rm(scratch, { force: true })
+      await addRef(hash, options.docUrl)
+      const existing = await statBlob(hash)
+      return {
+        meta:
+          existing ?? (await finalizeMeta(hash, size, options.mimeType, ext)),
+        deduped: true,
+      }
+    }
+
+    await mkdir(path.dirname(objectPath(hash)), { recursive: true })
+    await rename(scratch, objectPath(hash))
+    const meta = await finalizeMeta(hash, size, options.mimeType, ext)
+    await addRef(hash, options.docUrl)
+    return { meta, deduped: false }
+  }
+
+  /**
+   * Ingests a file already on the host's disk (the electron recording path).
+   * Hardlinks where possible so the bytes are not duplicated; note the
+   * consequence that deleting the file in Finder no longer frees the space
+   * until the store ref is released too.
+   */
+  async function ingestFile(
+    filepath: string,
+    options: { docUrl: string; mimeType?: string },
+  ): Promise<IngestFileResult> {
+    const ext = path.extname(filepath).toLowerCase()
+    const mimeType =
+      options.mimeType ??
+      MIME_TYPE_BY_EXTENSION[ext] ??
+      'application/octet-stream'
+
+    const hasher = crypto.createHash('sha256')
+    let size = 0
+    await pipeline(createReadStream(filepath), async function (chunks) {
+      for await (const chunk of chunks as AsyncIterable<Buffer>) {
+        size += chunk.length
+        hasher.update(chunk)
+      }
+    })
+    const hash = hasher.digest('hex')
+
+    if (await has(hash)) {
+      await addRef(hash, options.docUrl)
+      const existing = await statBlob(hash)
+      return {
+        meta: existing ?? (await finalizeMeta(hash, size, mimeType, ext)),
+        deduped: true,
+        mode: 'deduped',
+      }
+    }
+
+    const target = objectPath(hash)
+    await mkdir(path.dirname(target), { recursive: true })
+
+    let mode: IngestFileResult['mode'] = 'hardlink'
+    try {
+      await linkFile(filepath, target)
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code === 'EEXIST') {
+        // Raced with another ingest of the same content; the object is there.
+        mode = 'deduped'
+      } else if (code === 'EXDEV' || code === 'EPERM' || code === 'ENOTSUP') {
+        // Different filesystem (or one that will not link) — fall back to a
+        // real copy, staged through tmp so a crash cannot leave a partial
+        // object at its content address.
+        await mkdir(tmpDir, { recursive: true })
+        const scratch = path.join(tmpDir, crypto.randomUUID())
+        await copyFile(filepath, scratch)
+        await rename(scratch, target)
+        mode = 'copy'
+      } else {
+        throw error
+      }
+    }
+
+    const meta = await finalizeMeta(hash, size, mimeType, ext)
+    await addRef(hash, options.docUrl)
+    return { meta, deduped: mode === 'deduped', mode }
+  }
+
+  /** Total bytes held, for the store budget check on upload. */
+  async function totalBytes(): Promise<number> {
+    const objectsRoot = path.join(root, 'objects')
+    let total = 0
+    let shards: string[]
+    try {
+      shards = await readdir(objectsRoot)
+    } catch {
+      return 0
+    }
+    for (const dir of shards) {
+      let entries: string[]
+      try {
+        entries = await readdir(path.join(objectsRoot, dir))
+      } catch {
+        continue
+      }
+      for (const entry of entries) {
+        try {
+          total += (await stat(path.join(objectsRoot, dir, entry))).size
+        } catch {
+          // Raced with a delete; nothing to count.
+        }
+      }
+    }
+    return total
+  }
+
+  /** Clears uploads abandoned mid-stream. Run at startup. */
+  async function sweepTmp(maxAgeMs: number): Promise<number> {
+    let entries: string[]
+    try {
+      entries = await readdir(tmpDir)
+    } catch {
+      return 0
+    }
+    const cutoff = Date.now() - maxAgeMs
+    let removed = 0
+    for (const entry of entries) {
+      const target = path.join(tmpDir, entry)
+      try {
+        if ((await stat(target)).mtimeMs < cutoff) {
+          await rm(target, { force: true })
+          removed += 1
+        }
+      } catch {
+        // Already gone.
+      }
+    }
+    return removed
+  }
+
+  return {
+    has,
+    stat: statBlob,
+    read: readBlob,
+    refs: readRefs,
+    addRef,
+    releaseRef,
+    ingestStream,
+    ingestFile,
+    totalBytes,
+    sweepTmp,
+  }
+}

--- a/apps/electron-client/src/syncServer.ts
+++ b/apps/electron-client/src/syncServer.ts
@@ -14,8 +14,13 @@ import {
 import { automergeWasmBase64 } from '@automerge/automerge/automerge.wasm.base64'
 import { WebSocketServerAdapter } from '@automerge/automerge-repo-network-websocket'
 import { NodeFSStorageAdapter } from '@automerge/automerge-repo-storage-nodefs'
+import { createBlobStore, type BlobStore } from './blobStore'
+import { createBlobRequestHandler } from './blobHttp'
 
 export const DEFAULT_SYNC_SERVER_PORT = 9001
+
+/** Uploads abandoned mid-stream are cleared once they are a day old. */
+const TMP_SWEEP_MAX_AGE_MS = 24 * 60 * 60 * 1000
 
 export type SyncServerInfo = {
   running: boolean
@@ -25,6 +30,15 @@ export type SyncServerInfo = {
   webAppUrl?: string
   /** LAN-reachable URL of the hosted web-client bundle. */
   lanWebAppUrl?: string
+  /** Origin serving `/blobs`, when a blob store is configured. */
+  blobBaseUrl?: string
+  /** LAN-reachable origin serving `/blobs`. */
+  lanBlobBaseUrl?: string
+  /**
+   * Bearer token for `/blobs`. Handed to guests through the QR pairing URL;
+   * never log this object wholesale.
+   */
+  blobToken?: string
   port: number
   host: string
 }
@@ -54,6 +68,14 @@ export type SyncServerOptions = {
    * sync socket still runs here; the dev server proxies `/sync` back to it.
    */
   webAppDevUrl?: string
+  /**
+   * Root of the content-addressed audio store. When omitted the `/blobs`
+   * routes are still matched but answer 503, so the server keeps working (and
+   * keeps its tests passing) without one.
+   */
+  blobStorePath?: string
+  /** Bearer token guarding `/blobs`. */
+  blobToken?: string
 }
 
 type RunningSyncServer = {
@@ -61,6 +83,7 @@ type RunningSyncServer = {
   repo: Repo
   wss: WebSocketServer
   server: http.Server
+  blobStore?: BlobStore
 }
 
 let current: RunningSyncServer | null = null
@@ -74,6 +97,14 @@ export function getSyncServerInfo(): SyncServerInfo {
       host: '',
     }
   )
+}
+
+/**
+ * The running host's blob store, for the IPC channels that ingest a locally
+ * recorded file without going over HTTP.
+ */
+export function getBlobStore(): BlobStore | undefined {
+  return current?.blobStore
 }
 
 export function getLocalNetworkIp(): string | undefined {
@@ -115,11 +146,27 @@ const STATIC_MIME_TYPES: Record<string, string> = {
  * built web-client bundle (with an SPA fallback to index.html so deep links
  * like `/?am=<url>` work); otherwise it responds with a plain health check.
  */
-function createRequestHandler(webClientPath?: string) {
+function createRequestHandler(
+  webClientPath?: string,
+  handleBlobRequest?: (
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ) => Promise<boolean>,
+) {
   return async (
     request: http.IncomingMessage,
     response: http.ServerResponse,
   ) => {
+    // Ahead of everything, including the health check below: the static
+    // branch's SPA fallback answers any unmatched path with index.html and a
+    // 200, so a blob route mounted after it would return HTML to an <audio>
+    // element rather than a 404. The health-check branch returns early, so
+    // this must also precede it or blobs would break whenever no web-client
+    // bundle is staged (which is how both server test harnesses run).
+    if (handleBlobRequest && (await handleBlobRequest(request, response))) {
+      return
+    }
+
     if (!webClientPath) {
       response.writeHead(200, { 'Content-Type': 'text/plain' })
       response.end('tapes-sync-server')
@@ -164,6 +211,25 @@ function createRequestHandler(webClientPath?: string) {
   }
 }
 
+/**
+ * Stands in when no blob store is configured. It still *claims* the `/blobs`
+ * paths so they can never fall through to the SPA fallback and come back as a
+ * 200 page of HTML.
+ */
+async function unavailableBlobRequestHandler(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+): Promise<boolean> {
+  const pathname = new URL(request.url ?? '/', 'http://localhost').pathname
+  if (pathname !== '/blobs' && !pathname.startsWith('/blobs/')) {
+    return false
+  }
+  request.resume()
+  response.writeHead(503, { 'Content-Type': 'application/json; charset=utf-8' })
+  response.end(JSON.stringify({ error: 'Blob store not configured' }))
+  return true
+}
+
 function listen(server: http.Server, host: string, port: number) {
   return new Promise<number>((resolve, reject) => {
     const onError = (error: NodeJS.ErrnoException) => {
@@ -196,11 +262,31 @@ export async function startSyncServer(
     await initializeBase64Wasm(automergeWasmBase64)
   }
 
-  const { storagePath, host, peerId, webClientPath, tls, webAppDevUrl } =
-    options
+  const {
+    storagePath,
+    host,
+    peerId,
+    webClientPath,
+    tls,
+    webAppDevUrl,
+    blobStorePath,
+    blobToken,
+  } = options
   const requestedPort = options.port ?? DEFAULT_SYNC_SERVER_PORT
 
-  const handler = createRequestHandler(webClientPath)
+  const blobStore = blobStorePath ? createBlobStore(blobStorePath) : undefined
+  if (blobStore) {
+    // Best-effort: a failed sweep must not stop the server from starting.
+    void blobStore
+      .sweepTmp(TMP_SWEEP_MAX_AGE_MS)
+      .catch((error) => console.error('Blob tmp sweep failed:', error))
+  }
+
+  const handleBlobRequest = blobStore
+    ? createBlobRequestHandler({ store: blobStore, token: blobToken })
+    : unavailableBlobRequestHandler
+
+  const handler = createRequestHandler(webClientPath, handleBlobRequest)
   const server = tls
     ? https.createServer({ key: tls.key, cert: tls.cert }, handler)
     : http.createServer(handler)
@@ -249,12 +335,20 @@ export async function startSyncServer(
         (webClientPath && lanIp
           ? `${httpScheme}://${lanIp}:${port}`
           : undefined),
+      // Blobs are always served by this process, never by the web-client's
+      // dev server, so these ignore `webAppDevUrl`. In development the dev
+      // server proxies `/blobs` back here (see web-client's vite.config.ts).
+      blobBaseUrl: blobStore ? `${httpScheme}://127.0.0.1:${port}` : undefined,
+      lanBlobBaseUrl:
+        blobStore && lanIp ? `${httpScheme}://${lanIp}:${port}` : undefined,
+      blobToken: blobStore ? blobToken : undefined,
       port,
       host,
     },
     repo,
     wss,
     server,
+    blobStore,
   }
 
   console.log(`Sync server listening on ${wsScheme}://${host}:${port}`)
@@ -274,5 +368,10 @@ export async function stopSyncServer(): Promise<void> {
     client.terminate()
   }
   await new Promise<void>((resolve) => wss.close(() => resolve()))
+  // `server.close` only stops new connections; it waits for existing ones to
+  // end. Now that guests hold keep-alive HTTP connections for `/blobs`, that
+  // wait runs to the keep-alive timeout and stalls quitting the app (main.ts
+  // defers `will-quit` on this).
+  server.closeAllConnections()
   await new Promise<void>((resolve) => server.close(() => resolve()))
 }

--- a/apps/electron-client/src/syncServerConfig.ts
+++ b/apps/electron-client/src/syncServerConfig.ts
@@ -9,6 +9,11 @@ export type SyncServerConfig = {
   // Serve the LAN over self-signed HTTPS so guests get a secure context
   // (required for playback and recording, not just plain browsing).
   httpsEnabled: boolean
+  // Bearer token guarding the `/blobs` HTTP surface. The sync socket itself is
+  // still unauthenticated on the LAN, but blobs add a *write* endpoint that
+  // consumes the host's disk, so leaving those open would be strictly worse
+  // than the status quo. Distributed to guests via the QR pairing URL.
+  blobToken: string
 }
 
 const configFilePath = () =>
@@ -16,6 +21,11 @@ const configFilePath = () =>
 
 export const syncStoragePath = () =>
   path.join(app.getPath('userData'), 'sync-storage')
+
+/** Root of the content-addressed audio store served over `/blobs`. */
+export const blobStoragePath = () => path.join(app.getPath('userData'), 'blobs')
+
+const createBlobToken = () => crypto.randomBytes(32).toString('base64url')
 
 /**
  * Resolves the directory of the bundled web-client, staged as an
@@ -50,11 +60,22 @@ export function readSyncServerConfig(): SyncServerConfig {
       readFileSync(configFilePath(), 'utf-8'),
     ) as Partial<SyncServerConfig>
     if (typeof stored.peerId === 'string') {
-      return {
+      const config: SyncServerConfig = {
         peerId: stored.peerId,
         lanEnabled: stored.lanEnabled === true,
         httpsEnabled: stored.httpsEnabled === true,
+        // Configs written before blobs existed have no token; mint one and
+        // persist it so it stays stable across restarts (a token that changed
+        // every launch would unpair every guest).
+        blobToken:
+          typeof stored.blobToken === 'string' && stored.blobToken.length > 0
+            ? stored.blobToken
+            : createBlobToken(),
       }
+      if (config.blobToken !== stored.blobToken) {
+        writeSyncServerConfig(config)
+      }
+      return config
     }
   } catch {
     // Missing or corrupt config falls through to defaults.
@@ -64,6 +85,7 @@ export function readSyncServerConfig(): SyncServerConfig {
     peerId: `tapes-embedded-${crypto.randomUUID()}`,
     lanEnabled: false,
     httpsEnabled: false,
+    blobToken: createBlobToken(),
   }
   writeSyncServerConfig(config)
   return config

--- a/apps/electron-client/src/syncServerRuntime.ts
+++ b/apps/electron-client/src/syncServerRuntime.ts
@@ -5,6 +5,7 @@ import {
   type SyncServerInfo,
 } from './syncServer'
 import {
+  blobStoragePath,
   readSyncServerConfig,
   syncStoragePath,
   webClientDevUrl,
@@ -31,7 +32,9 @@ export async function startSyncServerFromConfig(): Promise<SyncServerInfo> {
   // for the production flow, where guests connect to this origin directly.
   const devWebAppUrl = webClientDevUrl()
   const tls =
-    config.httpsEnabled && !devWebAppUrl ? ensureSyncServerCert(lanIp) : undefined
+    config.httpsEnabled && !devWebAppUrl
+      ? ensureSyncServerCert(lanIp)
+      : undefined
 
   return startSyncServer({
     storagePath: syncStoragePath(),
@@ -40,6 +43,8 @@ export async function startSyncServerFromConfig(): Promise<SyncServerInfo> {
     webClientPath: webClientPath(),
     webAppDevUrl: devWebAppUrl,
     tls,
+    blobStorePath: blobStoragePath(),
+    blobToken: config.blobToken,
   })
 }
 

--- a/apps/web-client/vite.config.ts
+++ b/apps/web-client/vite.config.ts
@@ -85,7 +85,11 @@ const plugins = [
       // Belt and braces. The Automerge socket connects to `/sync` on this
       // origin; WebSocket upgrades are not `fetch` events so a worker never
       // sees them, but this guarantees the shell is never served in its place.
-      navigateFallbackDenylist: [/^\/sync/],
+      // `/blobs` is here for the same reason: those are `fetch` requests
+      // rather than navigations, so the fallback should not apply anyway, but
+      // serving the app shell in place of audio bytes fails as an opaque
+      // decode error and is worth ruling out explicitly.
+      navigateFallbackDenylist: [/^\/sync/, /^\/blobs/],
       cleanupOutdatedCaches: true,
     },
     // Deliberately off. A worker on the dev server would fight the LAN-guest
@@ -127,6 +131,14 @@ export default defineConfig({
       '/sync': {
         target: 'ws://127.0.0.1:9001',
         ws: true,
+        secure: false,
+        changeOrigin: true,
+      },
+      // Recorded audio is fetched and uploaded over the same origin as the
+      // sync socket, so it needs the same hop in development. Blobs are always
+      // served by the embedded host itself, never by this dev server.
+      '/blobs': {
+        target: 'http://127.0.0.1:9001',
         secure: false,
         changeOrigin: true,
       },

--- a/packages/core/app/IpcService.ts
+++ b/packages/core/app/IpcService.ts
@@ -31,6 +31,12 @@ export type SyncServerInfo = {
   webAppUrl?: string
   /** LAN-reachable URL of the hosted web-client bundle. */
   lanWebAppUrl?: string
+  /** Origin serving `/blobs`, when the host has a blob store configured. */
+  blobBaseUrl?: string
+  /** LAN-reachable origin serving `/blobs`. */
+  lanBlobBaseUrl?: string
+  /** Bearer token for `/blobs`. Never log this object wholesale. */
+  blobToken?: string
   port: number
   host: string
 }
@@ -153,9 +159,12 @@ export class IpcService {
 
     // This method returns a promise which will be resolved when the response has arrived.
     return new Promise((resolve) => {
-      ipcRenderer.receive(request.responseChannel ?? '', (...args: unknown[]) => {
-        resolve(args[0] as T)
-      })
+      ipcRenderer.receive(
+        request.responseChannel ?? '',
+        (...args: unknown[]) => {
+          resolve(args[0] as T)
+        },
+      )
     })
   }
 }

--- a/packages/core/app/blobClient.test.ts
+++ b/packages/core/app/blobClient.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  BlobRequestError,
+  deleteBlob,
+  fetchBlob,
+  headBlob,
+  resolveBlobEndpoint,
+  uploadBlob,
+} from './blobClient'
+
+const ENDPOINT = { baseUrl: 'http://127.0.0.1:9001', token: 'pair-token' }
+const DOC = 'automerge:doc-a'
+const HASH = 'a'.repeat(64)
+
+function stubFetch(response: Response) {
+  const fetchMock = vi.fn().mockResolvedValue(response)
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+const jsonResponse = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('resolveBlobEndpoint', () => {
+  it('prefers the embedded host advertised over IPC', () => {
+    expect(
+      resolveBlobEndpoint({
+        syncServerInfo: {
+          blobBaseUrl: 'http://127.0.0.1:9001/',
+          blobToken: 'host-token',
+        },
+        origin: 'http://localhost:3000',
+        isDev: true,
+      }),
+    ).toEqual({ baseUrl: 'http://127.0.0.1:9001', token: 'host-token' })
+  })
+
+  it('uses the page origin when the host serves this bundle', () => {
+    expect(
+      resolveBlobEndpoint({
+        origin: 'https://192.168.1.20:9001',
+        servedByHost: true,
+        token: 'pair-token',
+      }),
+    ).toEqual({ baseUrl: 'https://192.168.1.20:9001', token: 'pair-token' })
+  })
+
+  it('derives an http origin from a remote sync url', () => {
+    expect(
+      resolveBlobEndpoint({
+        remoteSyncServerUrl: 'wss://sync.example.com/sync',
+        token: 'pair-token',
+      }),
+    ).toEqual({ baseUrl: 'https://sync.example.com', token: 'pair-token' })
+  })
+
+  it('will not use a remote sync url without a pairing token', () => {
+    // Every request would 401, so there is nothing to be gained by trying.
+    expect(
+      resolveBlobEndpoint({
+        remoteSyncServerUrl: 'wss://sync.example.com/sync',
+      }),
+    ).toBeUndefined()
+  })
+
+  // A standalone web-client with no host is a supported configuration, not a
+  // failure: its bytes simply stay in OPFS.
+  it('returns undefined for a local-only client', () => {
+    expect(
+      resolveBlobEndpoint({ origin: 'https://tapes.example.com' }),
+    ).toBeUndefined()
+  })
+})
+
+describe('uploadBlob', () => {
+  it('posts the bytes and returns the descriptor', async () => {
+    const fetchMock = stubFetch(
+      jsonResponse(201, {
+        hash: HASH,
+        size: 12,
+        mimeType: 'audio/wav',
+        ext: '.wav',
+        deduped: false,
+      }),
+    )
+    const body = new Blob(['recorded'], { type: 'audio/wav' })
+
+    const descriptor = await uploadBlob(ENDPOINT, body, {
+      mimeType: 'audio/wav',
+      docUrl: DOC,
+    })
+
+    expect(descriptor).toEqual({
+      hash: HASH,
+      size: 12,
+      mimeType: 'audio/wav',
+      ext: '.wav',
+    })
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(
+      `http://127.0.0.1:9001/blobs?doc=${encodeURIComponent(DOC)}`,
+    )
+    expect(init.method).toBe('POST')
+    expect(init.headers).toMatchObject({
+      Authorization: 'Bearer pair-token',
+      'Content-Type': 'audio/wav',
+      'X-Tapes-Recording-Url': DOC,
+    })
+    // The File/Blob is handed to fetch as-is so it streams off disk rather
+    // than being read into memory.
+    expect(init.body).toBe(body)
+  })
+
+  it('throws a typed error carrying the status', async () => {
+    stubFetch(jsonResponse(413, { error: 'Blob exceeds the limit' }))
+
+    const failure = uploadBlob(ENDPOINT, new Blob(['x']), {
+      mimeType: 'audio/wav',
+      docUrl: DOC,
+    })
+
+    await expect(failure).rejects.toBeInstanceOf(BlobRequestError)
+    await expect(failure).rejects.toThrow('Blob exceeds the limit')
+  })
+})
+
+describe('fetchBlob', () => {
+  it('sends the bearer token and returns the bytes', async () => {
+    const fetchMock = stubFetch(
+      new Response('audio bytes', {
+        status: 200,
+        headers: { 'Content-Type': 'audio/wav' },
+      }),
+    )
+
+    const blob = await fetchBlob(ENDPOINT, HASH)
+
+    // jsdom's Blob has no `text()`, unlike a real browser's, so assert on the
+    // properties it does expose.
+    expect(blob.size).toBe('audio bytes'.length)
+    expect(blob.type).toBe('audio/wav')
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(`http://127.0.0.1:9001/blobs/${HASH}`)
+    expect(init.headers).toEqual({ Authorization: 'Bearer pair-token' })
+  })
+
+  it('rejects with the status when the host does not have it', async () => {
+    stubFetch(jsonResponse(404, { error: 'Unknown blob' }))
+
+    await expect(fetchBlob(ENDPOINT, HASH)).rejects.toMatchObject({
+      status: 404,
+    })
+  })
+
+  it('passes the abort signal through', async () => {
+    const fetchMock = stubFetch(new Response('x'))
+    const controller = new AbortController()
+
+    await fetchBlob(ENDPOINT, HASH, { signal: controller.signal })
+
+    expect(fetchMock.mock.calls[0][1].signal).toBe(controller.signal)
+  })
+})
+
+describe('headBlob', () => {
+  it('reports size and type without a body', async () => {
+    stubFetch(
+      new Response(null, {
+        status: 200,
+        headers: { 'Content-Length': '2048', 'Content-Type': 'audio/mp4' },
+      }),
+    )
+
+    await expect(headBlob(ENDPOINT, HASH)).resolves.toEqual({
+      size: 2048,
+      mimeType: 'audio/mp4',
+    })
+  })
+
+  it('returns null for an unknown hash', async () => {
+    stubFetch(new Response(null, { status: 404 }))
+
+    await expect(headBlob(ENDPOINT, HASH)).resolves.toBeNull()
+  })
+})
+
+describe('deleteBlob', () => {
+  it('releases this document’s claim on the bytes', async () => {
+    const fetchMock = stubFetch(new Response(null, { status: 204 }))
+
+    await deleteBlob(ENDPOINT, HASH, DOC)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe(
+      `http://127.0.0.1:9001/blobs/${HASH}?doc=${encodeURIComponent(DOC)}`,
+    )
+    expect(init.method).toBe('DELETE')
+  })
+
+  it('treats an already-deleted blob as success', async () => {
+    stubFetch(jsonResponse(404, { error: 'Unknown blob' }))
+
+    await expect(deleteBlob(ENDPOINT, HASH, DOC)).resolves.toBeUndefined()
+  })
+})

--- a/packages/core/app/blobClient.ts
+++ b/packages/core/app/blobClient.ts
@@ -1,0 +1,215 @@
+import type { SyncServerInfo } from './IpcService'
+import type { BlobDescriptor } from './types'
+
+/**
+ * Client for the host's `/blobs` surface.
+ *
+ * Recorded audio is addressed by the sha-256 of its bytes and lives on the
+ * sync host, not in the Automerge doc. Guests upload what they record and
+ * fetch what they play; the doc carries only the descriptor.
+ *
+ * The hash is always computed by the host while it streams the upload, never
+ * here: a phone would otherwise have to read a 50 MB+ file to hash it, and
+ * `crypto.subtle` is unavailable in the plain-HTTP LAN mode the host can be
+ * configured into.
+ */
+
+export type BlobEndpoint = {
+  /** Origin serving `/blobs`, without a trailing slash. */
+  baseUrl: string
+  token?: string
+}
+
+export class BlobRequestError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'BlobRequestError'
+  }
+}
+
+export type ResolveBlobEndpointInput = {
+  /** Electron only: the embedded host's own advertised surface. */
+  syncServerInfo?: Pick<SyncServerInfo, 'blobBaseUrl' | 'blobToken'>
+  /** Origin of the page, when there is one. */
+  origin?: string
+  /** True when this bundle is being served by the electron host. */
+  servedByHost?: boolean
+  isDev?: boolean
+  /** `ws(s)://host:port/sync` from settings, when the user set one. */
+  remoteSyncServerUrl?: string
+  /** Pairing token, stored by the web-client from the QR `bt` parameter. */
+  token?: string
+}
+
+/**
+ * Mirrors the sync-URL precedence in apps/web-client/src/syncServerUrl.ts, but
+ * lives here so both shells resolve it the same way.
+ *
+ * Returning `undefined` is a supported outcome, not a failure: a standalone
+ * web-client with no host has nowhere to put bytes, and keeps them in OPFS.
+ */
+export function resolveBlobEndpoint(
+  input: ResolveBlobEndpointInput,
+): BlobEndpoint | undefined {
+  const { syncServerInfo, origin, servedByHost, isDev, remoteSyncServerUrl } =
+    input
+
+  if (syncServerInfo?.blobBaseUrl) {
+    return {
+      baseUrl: trimSlash(syncServerInfo.blobBaseUrl),
+      token: syncServerInfo.blobToken,
+    }
+  }
+
+  if (origin && (servedByHost || isDev)) {
+    // Same origin as the page: in production this server serves both, and in
+    // development Vite proxies `/blobs` back to it.
+    return { baseUrl: trimSlash(origin), token: input.token }
+  }
+
+  if (remoteSyncServerUrl && input.token) {
+    // A remote host is only usable for blobs if we were also paired with it;
+    // without a token every request would just 401.
+    const derived = deriveHttpOrigin(remoteSyncServerUrl)
+    if (derived) {
+      return { baseUrl: derived, token: input.token }
+    }
+  }
+
+  return undefined
+}
+
+function trimSlash(value: string): string {
+  return value.replace(/\/+$/, '')
+}
+
+function deriveHttpOrigin(syncUrl: string): string | undefined {
+  try {
+    const url = new URL(syncUrl)
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+      return undefined
+    }
+    return `${url.protocol === 'wss:' ? 'https' : 'http'}://${url.host}`
+  } catch {
+    return undefined
+  }
+}
+
+function authHeaders(endpoint: BlobEndpoint): Record<string, string> {
+  return endpoint.token ? { Authorization: `Bearer ${endpoint.token}` } : {}
+}
+
+function blobUrl(endpoint: BlobEndpoint, hash: string): string {
+  return `${endpoint.baseUrl}/blobs/${hash}`
+}
+
+async function failure(response: Response): Promise<BlobRequestError> {
+  let message = response.statusText
+  try {
+    const body = (await response.json()) as { error?: string }
+    if (body.error) {
+      message = body.error
+    }
+  } catch {
+    // Non-JSON body; the status text will do.
+  }
+  return new BlobRequestError(response.status, message)
+}
+
+/**
+ * Uploads recorded bytes and returns the descriptor to write into the doc.
+ *
+ * `body` should be the OPFS `File` handle rather than a materialized buffer —
+ * `fetch` streams it off disk, so a large recording never has to fit in JS
+ * memory on a phone.
+ */
+export async function uploadBlob(
+  endpoint: BlobEndpoint,
+  body: Blob,
+  options: { mimeType: string; docUrl: string; signal?: AbortSignal },
+): Promise<BlobDescriptor> {
+  const response = await fetch(
+    `${endpoint.baseUrl}/blobs?doc=${encodeURIComponent(options.docUrl)}`,
+    {
+      method: 'POST',
+      headers: {
+        ...authHeaders(endpoint),
+        'Content-Type': options.mimeType,
+        'X-Tapes-Recording-Url': options.docUrl,
+      },
+      body,
+      signal: options.signal,
+    },
+  )
+
+  if (!response.ok) {
+    throw await failure(response)
+  }
+
+  const descriptor = (await response.json()) as BlobDescriptor
+  return {
+    hash: descriptor.hash,
+    size: descriptor.size,
+    mimeType: descriptor.mimeType,
+    ext: descriptor.ext,
+  }
+}
+
+export async function fetchBlob(
+  endpoint: BlobEndpoint,
+  hash: string,
+  options: { signal?: AbortSignal } = {},
+): Promise<Blob> {
+  const response = await fetch(blobUrl(endpoint, hash), {
+    headers: authHeaders(endpoint),
+    signal: options.signal,
+  })
+  if (!response.ok) {
+    throw await failure(response)
+  }
+  return response.blob()
+}
+
+/** Presence check without transferring the body. Null when the host has no such blob. */
+export async function headBlob(
+  endpoint: BlobEndpoint,
+  hash: string,
+): Promise<{ size: number; mimeType: string } | null> {
+  const response = await fetch(blobUrl(endpoint, hash), {
+    method: 'HEAD',
+    headers: authHeaders(endpoint),
+  })
+  if (response.status === 404) {
+    return null
+  }
+  if (!response.ok) {
+    throw await failure(response)
+  }
+  return {
+    size: Number(response.headers.get('content-length') ?? 0),
+    mimeType:
+      response.headers.get('content-type') ?? 'application/octet-stream',
+  }
+}
+
+/**
+ * Releases this recording's claim on the bytes. The host unlinks them once no
+ * document references the hash any more.
+ */
+export async function deleteBlob(
+  endpoint: BlobEndpoint,
+  hash: string,
+  docUrl: string,
+): Promise<void> {
+  const response = await fetch(
+    `${blobUrl(endpoint, hash)}?doc=${encodeURIComponent(docUrl)}`,
+    { method: 'DELETE', headers: authHeaders(endpoint) },
+  )
+  // A blob that is already gone is a success from the caller's point of view.
+  if (!response.ok && response.status !== 404) {
+    throw await failure(response)
+  }
+}

--- a/packages/core/app/types.ts
+++ b/packages/core/app/types.ts
@@ -1,5 +1,20 @@
 import { AutomergeUrl } from '@automerge/automerge-repo'
 
+/**
+ * Where a recording's audio lives once it is out of the Automerge doc: the
+ * sha-256 of the bytes, which is also its address in the host's blob store.
+ *
+ * Not yet written to `RecordingData` — the recorder starts producing these
+ * when playback can resolve them.
+ */
+export type BlobDescriptor = {
+  hash: string
+  size: number
+  mimeType: string
+  /** Leading-dot extension, e.g. '.wav'. */
+  ext: string
+}
+
 export type RecordingData = {
   url: AutomergeUrl
   filename: string

--- a/packages/core/app/workerClient.test.ts
+++ b/packages/core/app/workerClient.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest'
+import { callWorker, WorkerRequestError } from './workerClient'
+
+/**
+ * Stands in for the web-client's storage worker. Colocated rather than shipped
+ * as a module so the library build never picks it up.
+ */
+class FakeWorker extends EventTarget {
+  readonly sent: Array<{ type: string; payload: Record<string, unknown> }> = []
+
+  constructor(
+    private readonly reply: (
+      message: { type: string; payload: Record<string, unknown> },
+      worker: FakeWorker,
+    ) => Record<string, unknown> | undefined,
+  ) {
+    super()
+  }
+
+  postMessage(message: { type: string; payload: Record<string, unknown> }) {
+    this.sent.push(message)
+    const response = this.reply(message, this)
+    if (response) {
+      this.emit(response)
+    }
+  }
+
+  emit(data: Record<string, unknown>) {
+    queueMicrotask(() => {
+      this.dispatchEvent(new MessageEvent('message', { data }))
+    })
+  }
+}
+
+const asWorker = (fake: FakeWorker) => fake as unknown as Worker
+
+describe('callWorker', () => {
+  it('resolves with the payload of the matching reply', async () => {
+    const fake = new FakeWorker(({ type, payload }) => ({
+      type: `${type}:response`,
+      requestId: payload.requestId,
+      success: true,
+      payload: { bytes: 42 },
+    }))
+
+    await expect(
+      callWorker<{ bytes: number }>(asWorker(fake), 'blob:get', {
+        hash: 'abc',
+      }),
+    ).resolves.toEqual({ bytes: 42 })
+    expect(fake.sent[0].payload).toMatchObject({ hash: 'abc' })
+  })
+
+  it('rejects when the worker reports failure', async () => {
+    const fake = new FakeWorker(({ type, payload }) => ({
+      type: `${type}:response`,
+      requestId: payload.requestId,
+      success: false,
+      error: 'NotFoundError',
+    }))
+
+    await expect(
+      callWorker(asWorker(fake), 'blob:get', { hash: 'abc' }),
+    ).rejects.toThrow(WorkerRequestError)
+  })
+
+  // The whole point of the helper: the worker is one switch with no
+  // correlation, so overlapping requests used to be able to take each other's
+  // replies.
+  it('routes overlapping requests to their own callers', async () => {
+    const pending: Array<{ requestId: unknown; hash: unknown }> = []
+    const fake = new FakeWorker(({ payload }) => {
+      pending.push({ requestId: payload.requestId, hash: payload.hash })
+      return undefined
+    })
+
+    const first = callWorker<string>(asWorker(fake), 'blob:get', { hash: 'a' })
+    const second = callWorker<string>(asWorker(fake), 'blob:get', { hash: 'b' })
+
+    // Answer out of order, as a worker reading two files would.
+    fake.emit({
+      type: 'blob:get:response',
+      requestId: pending[1].requestId,
+      success: true,
+      payload: 'second',
+    })
+    fake.emit({
+      type: 'blob:get:response',
+      requestId: pending[0].requestId,
+      success: true,
+      payload: 'first',
+    })
+
+    await expect(second).resolves.toBe('second')
+    await expect(first).resolves.toBe('first')
+  })
+
+  it('ignores replies that carry no matching request id', async () => {
+    const fake = new FakeWorker(() => undefined)
+    const settled = vi.fn()
+    const promise = callWorker(asWorker(fake), 'blob:get', {}).then(settled)
+
+    fake.emit({ type: 'blob:get:response', success: true, payload: 'stray' })
+    await Promise.resolve()
+
+    expect(settled).not.toHaveBeenCalled()
+
+    const requestId = fake.sent[0].payload.requestId
+    fake.emit({
+      type: 'blob:get:response',
+      requestId,
+      success: true,
+      payload: 'mine',
+    })
+    await promise
+    expect(settled).toHaveBeenCalledWith('mine')
+  })
+
+  it('rejects and stops listening when the caller aborts', async () => {
+    const fake = new FakeWorker(() => undefined)
+    const controller = new AbortController()
+
+    const promise = callWorker(
+      asWorker(fake),
+      'blob:get',
+      {},
+      {
+        signal: controller.signal,
+      },
+    )
+    controller.abort()
+
+    await expect(promise).rejects.toThrow('Aborted')
+  })
+})

--- a/packages/core/app/workerClient.ts
+++ b/packages/core/app/workerClient.ts
@@ -1,0 +1,85 @@
+/**
+ * Request/response helper for the web-client's storage worker.
+ *
+ * The worker's `onmessage` is one switch with no correlation between a request
+ * and its reply, and callers have so far each hand-rolled an
+ * `addEventListener`/`removeEventListener` dance around it. That is fine while
+ * only one request is ever in flight, but blob fetches can overlap with each
+ * other and with a save. Tagging every message with a `requestId` and routing
+ * replies through one place fixes that, and gives tests a single seam to fake.
+ */
+
+export type WorkerResponse<T> = {
+  type: string
+  requestId?: string
+  success: boolean
+  payload?: T
+  error?: string
+}
+
+export class WorkerRequestError extends Error {
+  constructor(
+    readonly requestType: string,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'WorkerRequestError'
+  }
+}
+
+let counter = 0
+
+function nextRequestId(): string {
+  // Not `Date.now()`: two sends in the same millisecond would collide, which
+  // is exactly the bug this helper exists to avoid.
+  counter += 1
+  return `${counter}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+export function callWorker<T>(
+  worker: Worker,
+  type: string,
+  payload: Record<string, unknown> = {},
+  options: { transfer?: Transferable[]; signal?: AbortSignal } = {},
+): Promise<T> {
+  const requestId = nextRequestId()
+
+  return new Promise<T>((resolve, reject) => {
+    const settle = (run: () => void) => {
+      worker.removeEventListener('message', onMessage)
+      options.signal?.removeEventListener('abort', onAbort)
+      run()
+    }
+
+    const onMessage = (event: MessageEvent) => {
+      const data = event.data as WorkerResponse<T> | undefined
+      if (!data || data.requestId !== requestId) {
+        return
+      }
+      if (!data.success) {
+        settle(() =>
+          reject(new WorkerRequestError(type, data.error ?? 'Worker error')),
+        )
+        return
+      }
+      settle(() => resolve(data.payload as T))
+    }
+
+    const onAbort = () => {
+      settle(() => reject(new DOMException('Aborted', 'AbortError')))
+    }
+
+    if (options.signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+
+    worker.addEventListener('message', onMessage)
+    options.signal?.addEventListener('abort', onAbort)
+
+    worker.postMessage(
+      { type, payload: { ...payload, requestId } },
+      options.transfer ?? [],
+    )
+  })
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,4 +1,6 @@
 export * from './app/App'
 export * from './app/IpcService'
 export * from './app/types'
+export * from './app/blobClient'
+export * from './app/workerClient'
 export { useAutomergeUrl } from './app/utils'


### PR DESCRIPTION
PR 1 of 2 for [TAP-71](https://linear.app/tapes/issue/TAP-71/sync-recording-metadata-only-move-audio-bytes-out-of-band). **Purely additive — nothing user-visible changes.** `RecordingData` is untouched and recordings still embed their audio; PR 2 does the cutover.

## Why

`RecordingData.audio` puts the raw recorded bytes in the Automerge doc, so the CRDT is the blob transport: every peer stores every recording in full, Automerge history means deleting a recording never reclaims the space, and sync cost scales with total library size rather than with what a device actually plays. TAP-69 raised the ceiling on the host; it did not change the growth rate, and did nothing for web guests on IndexedDB/OPFS quota.

Worth noting, since the ticket did not record it: there is already a 50 MB embed cap (`MAX_EMBEDDED_AUDIO_BYTES`), so recordings above it are *silently* never synced today — only a `console.warn`. That cap goes away with the embedding in PR 2.

## What's here

**`blobStore.ts`** — content-addressed store at `userData/blobs`, `objects/<aa>/<hash>` with a two-char fanout (a flat directory degrades badly on ext4/NTFS once a library grows).

`ingestFile` **hardlinks** the user's recording into the store rather than copying it. This is the crux: the path is not stable, because audio lives in a directory the user chose and `EditRecordingChannel` renames the file on disk whenever a recording is retitled. Sharing an inode means a rename cannot break serving — there's a test for exactly that. Falls back to a real copy on `EXDEV`/`EPERM`/`ENOTSUP`.

One consequence to be aware of: deleting the file in Finder no longer frees the space until the store ref is released too.

Objects are refcounted by owning document url (`refs/<aa>/<hash>.json`, atomic writes serialized by a per-hash in-process mutex). Last owner released → bytes unlinked. That is what will let deleting a recording actually reclaim space.

**Hashing is done by the host, never the client.** The guest hands `fetch` its OPFS `File` and the host hashes while streaming it to disk. A phone would otherwise have to read a 50 MB+ file to hash it, and `crypto.subtle` is unavailable in the plain-HTTP LAN mode the host can be configured into.

**`blobHttp.ts`** — `POST /blobs`, `GET|HEAD /blobs/:hash` (range-capable so `<audio>` can seek), `DELETE /blobs/:hash?doc=`, `OPTIONS`. Immutable `Cache-Control` and an `ETag` of the hash, both free given content addressing.

**Routing order is load-bearing.** These mount ahead of everything in `createRequestHandler`, *including* the `!webClientPath` health-check early return. The static handler's SPA fallback answers any unmatched path with `index.html` and a **200**, so a blob route mounted after it would not 404 — it would hand an `<audio>` element a page of HTML, which surfaces as an opaque decode error. Two tests guard the ordering, and the early return matters because both existing server test harnesses run with no bundle staged.

**Auth.** Bearer token minted into `sync-server.json` (`readSyncServerConfig`'s existing early-return branch mints and persists one when absent, so it stays stable across restarts — a token that changed each launch would unpair every guest). Accepted as a header or `?t=`, compared with `timingSafeEqual`. The sync socket is already unauthenticated on the LAN, but blobs add a *write* endpoint that consumes the host's disk, so leaving them open would be strictly worse than the status quo. **This does not authenticate `/sync`** — the token is the primitive that makes that possible, as a follow-up.

**Core** — `blobClient` (`uploadBlob`/`fetchBlob`/`headBlob`/`deleteBlob`/`resolveBlobEndpoint`) and `callWorker`, a request/response helper giving the storage worker correlated request ids so overlapping requests can no longer take each other's replies. `resolveBlobEndpoint` returning `undefined` is a supported outcome, not a failure: a standalone web-client with no host keeps its bytes in OPFS.

## Drive-by fix

`stopSyncServer` hung on keep-alive connections. `server.close()` only stops *new* connections and waits for existing ones to end, which now runs to the keep-alive timeout — and `main.ts` defers `will-quit` on it, so quitting the app would stall. Surfaced as consistent 3s stalls in the new HTTP tests; `closeAllConnections()` fixes both.

## Verification

- `electron-client` 55 tests, `core` 39, `web-client` 14 — all pass. 30 of those are new.
- Blob HTTP tests drive a **real** server on port 0 with real `fetch`, in the style of the existing `syncServer.test.ts`. Store tests use real temp filesystems; the `EXDEV` fallback is injected since CI has no second filesystem.
- `tsc --noEmit` and `eslint` clean across all three packages (the one remaining warning is pre-existing in `AudioPlayerContext.tsx`, untouched here).
- `core` and `web-client` build, including the Automerge wasm precache check.

## Not here, deliberately

- `cacheServer.ts` / `tapes://` are untouched. The new route should eventually subsume them (that one hashes the *filepath*, copies with no `mkdir`, and its production cache dir is inside `resourcesPath`), but changing a signed-app production path on the critical path of a doc-shape migration is a bad trade.
- No blob GC beyond refcounting and a tmp sweep. A crash between writing an object and recording its ref leaves an orphan.
- `apps/api` gets no blob endpoint — LAN/host-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)