### PR TITLE
fix(core, web-client): tailwind lint warnings

### DIFF
--- a/.changeset/easy-impalas-bet.md
+++ b/.changeset/easy-impalas-bet.md
@@ -1,0 +1,6 @@
+---
+'web-client': patch
+'@tapes-monorepo/core': patch
+---
+
+Replace custom css values with tailwind class equivalents

--- a/apps/web-client/src/DownloadPrompt.tsx
+++ b/apps/web-client/src/DownloadPrompt.tsx
@@ -19,7 +19,7 @@ export default function DownloadPrompt() {
       {url ? (
         <QRCodeSVG value={url} fgColor="#18181b" />
       ) : (
-        <div className="size-[128px]" />
+        <div className="size-32" />
       )}
     </>
   )

--- a/packages/core/app/views/Library.tsx
+++ b/packages/core/app/views/Library.tsx
@@ -395,7 +395,7 @@ function Editor({
             })
           }
         >
-          <p className="size-full h-[5rem] overflow-y-auto p-1 whitespace-pre-line">
+          <p className="size-full h-20 overflow-y-auto p-1 whitespace-pre-line">
             {(recording.description &&
               recording.description?.length > 0 &&
               recording.description) ||
@@ -480,7 +480,7 @@ function EditableText({
               error === undefined && label !== undefined,
             'h-0 translate-y-full opacity-0':
               error === undefined && label === undefined,
-            'h-[1rem] translate-y-0 text-rose-500 opacity-100 peer-focus:text-rose-500':
+            'h-4 translate-y-0 text-rose-500 opacity-100 peer-focus:text-rose-500':
               error !== undefined,
           },
         )}
@@ -516,7 +516,7 @@ function EditableText({
       ) : (
         <textarea
           ref={textAreaRef}
-          className="size-full h-[5rem] p-1 text-zinc-800 outline-hidden dark:bg-zinc-900 dark:text-white"
+          className="size-full h-20 p-1 text-zinc-800 outline-hidden dark:bg-zinc-900 dark:text-white"
           autoFocus={true}
           id="description"
           name="description"

--- a/packages/core/app/views/Recorder.tsx
+++ b/packages/core/app/views/Recorder.tsx
@@ -166,7 +166,7 @@ export function Recorder() {
       <div className="flex flex-col">
         <div
           ref={visualizerContainerRef}
-          className="absolute top-0 right-0 bottom-[80px] left-0"
+          className="absolute top-0 right-0 bottom-20 left-0"
         >
           {audioInputDeviceId && isMonitoring && (
             <>
@@ -210,14 +210,14 @@ export function Recorder() {
       </div>
       <div
         className={clsx(
-          'fixed bottom-[79px] left-0 w-screen rounded-t-lg border border-zinc-100 bg-white text-zinc-400 transition-transform dark:border-zinc-800 dark:bg-zinc-900',
+          'fixed bottom-19.75 left-0 w-screen rounded-t-lg border border-zinc-100 bg-white text-zinc-400 transition-transform dark:border-zinc-800 dark:bg-zinc-900',
           {
             'translate-y-0 px-4 drop-shadow-2xl': isEditorOpen,
             'translate-y-full': !isEditorOpen,
           },
         )}
       >
-        <div className="group flex size-full h-[82px] items-center justify-between">
+        <div className="group flex size-full h-20.5 items-center justify-between">
           {isEditing ? (
             <div className="w-full justify-center p-4">
               <TextInput


### PR DESCRIPTION
Replaces custom values with tailwind class equivalents.

### Before:
<img width="520" height="664" alt="before" src="https://github.com/user-attachments/assets/222e5655-8977-458e-8827-b68557cc6a72" />

### After:
<img width="520" height="664" alt="after" src="https://github.com/user-attachments/assets/29fa9b5c-9eef-44e9-a0cb-e6bd27028823" />
